### PR TITLE
Revise API [breaking change]

### DIFF
--- a/examples/signal_listener.rs
+++ b/examples/signal_listener.rs
@@ -5,13 +5,13 @@ use notify_rust::NotificationHint as Hint;
 
 fn main()
 {
-
     Notification::new()
         .summary("click me")
         .action("default", "default")
         .action("clicked", "click here")
         .hint(Hint::Resident(true))
-        .show_and_wait_for_action({|action|
+        .show()
+        .wait_for_action({|action|
             match action {
                 "default" => {println!("so boring")},
                 "clicked" => {println!("that was correct")},

--- a/examples/update.rs
+++ b/examples/update.rs
@@ -2,41 +2,18 @@ extern crate notify_rust;
 use notify_rust::Notification;
 fn main()
 {
-    let naive = false; // change this to switch between moth implementation styles
+    let mut notification = Notification::new()
+        .summary("Firefox Crashed")
+        .body("Just <b>kidding</b>, this is just the notify_show example.")
+        .icon("firefox")
+        .show();
 
-    if naive {
+    std::thread::sleep_ms(1_500);
 
-        // naive way to update a notification
-        let mut notification = Notification::new()
-            .summary("Firefox Crashed")
-            .body("Just <b>kidding</b>, this is just the notify_show example.")
-            .icon("firefox").finalize();
-        let id = notification.show();
-        std::thread::sleep_ms(1_500);
-        notify_rust::close_notification(id);
-        notification
-            //.appname("foo") // changing appname to keep plasma from merging both notifications
-            .body("wait, something has changed")
-            .show();
+    notification
+        .appname("foo") // changing appname to keep plasma from merging the new and the old one
+        .body("wait, something has changed");
 
-    }
-
-    else {
-
-        // the new and shiny api for updating
-        let mut notification = Notification::new()
-            .summary("Firefox Crashed")
-            .body("Just <b>kidding</b>, this is just the notify_show example.")
-            .icon("firefox").finalize();
-        notification.show();
-        std::thread::sleep_ms(1_500);
-        notification
-            .appname("foo") // changing appname to keep plasma from merging the new and the old one
-            .body("wait, something has changed")
-            .update();
-
-    }
-
-
+    notification.update();
 }
 

--- a/examples/wait_for_closing.rs
+++ b/examples/wait_for_closing.rs
@@ -1,11 +1,12 @@
 extern crate notify_rust;
 
-use notify_rust::Notification;
+use notify_rust::{Notification,NotificationHint};
 
 fn main()
 {
     Notification::new()
         .summary("Don't Mind me")
+        .hint(NotificationHint::Transient(true))
         .body("I'll be gone soon enough.\nSorry for the inconvenience.")
         .show_and_wait_for_action({|action|
             match action {

--- a/examples/wait_for_closing.rs
+++ b/examples/wait_for_closing.rs
@@ -8,7 +8,8 @@ fn main()
         .summary("Don't Mind me")
         .hint(NotificationHint::Transient(true))
         .body("I'll be gone soon enough.\nSorry for the inconvenience.")
-        .show_and_wait_for_action({|action|
+        .show()
+        .wait_for_action({|action|
             match action {
                 "__closed" => {println!("the notification was closed")}, // here "__closed" is a hardcoded keyword
                 _ => ()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ impl NotificationHandle
     {
         let mut message = build_message("CloseNotification");
         message.append_items(&[ self.id.into() ]);
-        self.connection.send(message);
+        let _ = self.connection.send(message); // If closing fails there's nothing we could do anyway
     }
 
     /// Replace the original notification with an updated version

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,11 +4,11 @@ use notify_rust::Notification;
 #[test]
 fn closing()
 {
-    let id = Notification::new()
+    Notification::new()
         .summary("You see me")
         .body("you don't see me!")
-        .show();
-    notify_rust::close_notification(id);
+        .show()
+        .close();
 }
 
 #[test]


### PR DESCRIPTION
I moved functionality for displayed notifications to NotificationHandle.
The old way of doing things was removed since it allowed to mess up things too easily.
Affected is notably the way you `close`, `wait_for_action` and `update` ([see how the examples change](https://github.com/panicbit/notify-rust/commit/37f93b742dd694c47a37e5b960fe32beb9f68ef9)).