### PR TITLE
Use cfg(unix) instead of linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["desktop", "notification", "notify", "dbus", "libnotify"]
 readme = "README.md"
 
 [dependencies]
-dbus = "~0.2"
+dbus = "~0.3"
 clippy = {version = "~0.0.23", optional = true}
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,9 @@ use std::collections::HashSet;
 use std::borrow::Cow;
 use std::ops::{Deref,DerefMut};
 
-#[cfg(target_os="linux")]
+#[cfg(all(unix, not(target_os = "macos")))]
 extern crate dbus;
-#[cfg(target_os="linux")]
+#[cfg(all(unix, not(target_os = "macos")))]
 use dbus::{Connection, ConnectionItem, BusType, Message, MessageItem, Error};
 
 mod util;
@@ -287,7 +287,7 @@ impl Notification {
         Ok(NotificationHandle::new(id, connection, self.clone()))
     }
 
-    #[cfg(target_os="linux")]
+    #[cfg(all(unix, not(target_os = "macos")))]
     fn _show(&mut self, id:u32, connection: &Connection) -> Result<u32, Error> {
         //TODO catch this
         let mut message = build_message("Notify");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
         missing_copy_implementations,
         trivial_casts, trivial_numeric_casts,
         unsafe_code,
-        unstable_features,
+        //unstable_features,
         unused_import_braces, unused_qualifications)]
 #![warn(missing_debug_implementations)]
 
@@ -76,7 +76,9 @@ use std::collections::HashSet;
 use std::borrow::Cow;
 use std::ops::{Deref,DerefMut};
 
+#[cfg(target_os="linux")]
 extern crate dbus;
+#[cfg(target_os="linux")]
 use dbus::{Connection, ConnectionItem, BusType, Message, MessageItem, Error};
 
 mod util;
@@ -285,6 +287,7 @@ impl Notification {
         Ok(NotificationHandle::new(id, connection, self.clone()))
     }
 
+    #[cfg(target_os="linux")]
     fn _show(&mut self, id:u32, connection: &Connection) -> Result<u32, Error> {
         //TODO catch this
         let mut message = build_message("Notify");
@@ -306,6 +309,10 @@ impl Notification {
             Some(&MessageItem::UInt32(ref id)) => Ok(*id),
             _ => Ok(0)
         }
+    }
+
+    #[cfg(target_os="macos")]
+    fn _show(&mut self, id:u32, connection: &Connection) -> Result<u32, Error> {
     }
 
     /// Wraps show() but prints notification to stdout.
@@ -559,4 +566,3 @@ fn unwrap_message_string(item: Option<&MessageItem>) -> String {
         _ => "".to_owned()
     }
 }
-


### PR DESCRIPTION
Hi.

Please don't hardcode "linux" when you mean "any UNIX-like OS" ;-)

With this change and diwic/dbus-rs#36, all tests pass on FreeBSD.