### PR TITLE
added custom int option

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,11 @@ use dbus::MessageItem;
 //TODO get rid of the util functions
 
 pub fn unwrap_message_int(item: &MessageItem) -> i32{
-    unwrap_message_str(item).parse::<i32>().unwrap_or(0)
+    try_unwrap_message_int(item).unwrap_or(0)
+}
+
+pub fn try_unwrap_message_int(item: &MessageItem) -> Option<i32> {
+    unwrap_message_str(item).parse::<i32>().ok()
 }
 
 pub fn unwrap_message_bool(item: &MessageItem) -> bool{


### PR DESCRIPTION
When you want to display a volume bar you need a hint with an `int` value. So this PR adds a `CustomInt` variant to the `NotificationHint` enum.
![screenshot from 2016-02-27 13 35 58](https://cloud.githubusercontent.com/assets/4401220/13374604/c83ef65e-dd57-11e5-960f-2df70b7040cc.png)
