### PR TITLE
Changed wait_for_action to return the action

### DIFF
--- a/examples/actions.rs
+++ b/examples/actions.rs
@@ -1,11 +1,11 @@
 extern crate notify_rust;
 
-use notify_rust::Notification;
+use notify_rust::{Action, Notification};
 use notify_rust::NotificationHint as Hint;
 
 fn main()
 {
-    Notification::new()
+    let mut notification = Notification::new()
         .summary("click me")
 
         .action("default", "default")    // IDENTIFIER, LABEL
@@ -13,14 +13,16 @@ fn main()
 
         .hint(Hint::Resident(true))
         .show()
-        .unwrap()
-        .wait_for_action({|action|
-            match action {
-                "default"  => println!("so boring"),
-                "clicked"  => println!("that was correct"),
-                // here "__closed" is a hardcoded keyword
-                "__closed" => println!("the notification was closed"),
-                _ => ()
+        .unwrap();
+
+    match notification.wait_for_action() {
+        Action::NotificationClosed => println!("the notification was closed"),
+        Action::ActionInvoked(action) => {
+            match &*action {
+                "default" => println!("so boring"),
+                "clicked" => println!("that was correct"),
+                _ => (),
             }
-        });
+        }
+    }
 }

--- a/examples/on_close.rs
+++ b/examples/on_close.rs
@@ -21,8 +21,9 @@ fn main() {
                   .body("This will go away.")
                   .icon("clock")
                   .show()
-                  .map(|handler| handler.on_close(|| print()))
-                 );
+                  .map(|mut handler| {
+                      handler.wait_for_close();
+                      print();}));
     wait_for_keypress();
 }
 

--- a/examples/wait_for_closing.rs
+++ b/examples/wait_for_closing.rs
@@ -9,10 +9,6 @@ fn main()
         .hint(NotificationHint::Transient(true))
         .body("I'll be gone soon enough.\nSorry for the inconvenience.")
         .show().unwrap()
-        .wait_for_action({|action|
-            match action {
-                "__closed" => {println!("the notification was closed")}, // here "__closed" is a hardcoded keyword
-                _ => ()
-            }
-        });
+        .wait_for_close();
+        println!("the notification was closed");
 }


### PR DESCRIPTION
This changes the `wait_for_action` method to return an `Action` instead of taking a closure. The return value is a new enum `Action` which gets rid of the magic string "__closed" for the NotificationClosed event. The method also takes the `self` argument by mutable reference instead of by value because someone may want to wait for an action and wait for the notification to be closed. It also removes the `on_close` method and replaces it with a `wait_for_close` method.

This seems like more idiomatic rust, but it is certainly a breaking change.