### PR TITLE
More windows support progress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,7 @@ image = {version = "0.13", optional = true}
 mac-notification-sys = "0.1"
 
 [target.'cfg(target_os="windows")'.dependencies]
-winrt-notification = "0.1.4"
-winrt = "0.3.0"
-
+winrt-notification = "0.2.1"
 
 [features]
 default = []

--- a/examples/countdown.rs
+++ b/examples/countdown.rs
@@ -3,6 +3,10 @@ use notify_rust::Notification;
 use std::time::Duration;
 
 #[cfg(target_os = "macos")] fn main() { println!("this is a xdg only feature") }
+
+#[cfg(target_os = "windows")]
+fn main() { println!("this is a xdg only feature") }
+
 #[cfg(all(unix, not(target_os = "macos")))]
 fn main() {
     let mut notification = Notification::new()

--- a/examples/images.rs
+++ b/examples/images.rs
@@ -10,6 +10,9 @@ use notify_rust::NotificationImage as Image;
 #[cfg(target_os = "macos")]
 fn main() { println!("this is a xdg only feature") }
 
+#[cfg(target_os = "windows")]
+fn main() { println!("this is a xdg only feature") }
+
 #[cfg(all(not(feature = "images"), unix, not(target_os = "macos")))]
 fn main() { println!("please build with '--features=images'") }
 

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -17,3 +17,6 @@ fn main() {
 }
 
 #[cfg(target_os = "macos")] fn main() { println!("this is a xdg only feature") }
+
+#[cfg(target_os = "windows")]
+fn main() { println!("this is a xdg only feature") }

--- a/examples/on_close.rs
+++ b/examples/on_close.rs
@@ -15,6 +15,10 @@ fn print(){
 }
 
 #[cfg(target_os = "macos")] fn main() { println!("this is a xdg only feature") }
+
+#[cfg(target_os = "windows")]
+fn main() { println!("this is a xdg only feature") }
+
 #[cfg(all(unix, not(target_os = "macos")))]
 fn main() {
     thread::spawn(||

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,6 +7,10 @@ use notify_rust::server::NotificationServer;
 use notify_rust::Notification;
 
 #[cfg(target_os = "macos")] fn main() { println!("this is a xdg only feature") }
+
+#[cfg(target_os = "windows")]
+fn main() { println!("this is a xdg only feature") }
+
 #[cfg(all(unix, not(target_os = "macos")))]
 fn main() {
     let mut server = NotificationServer::new();

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -8,6 +8,8 @@ static SOUND: &'static str = "Ping";
 #[cfg(all(unix, not(target_os = "macos")))]
 static SOUND: &'static str ="message-new-instant";
 
+#[cfg(target_os = "windows")]
+static SOUND: &'static str = "Mail";
 
 fn main() {
     Notification::new()

--- a/examples/update.rs
+++ b/examples/update.rs
@@ -2,6 +2,10 @@ extern crate notify_rust;
 use notify_rust::Notification;
 use std::time::Duration;
 
+
+#[cfg(target_os = "windows")]
+fn main() { println!("This is not a windows feature") }
+
 #[cfg(all(unix, not(target_os = "macos")))]
 fn update_via_handle() {
     let mut notification_handle = Notification::new()

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -1,17 +1,10 @@
 extern crate notify_rust;
-extern crate winrt;
 use notify_rust::Notification;
 
 fn main() {
-
-    let rt = winrt::RuntimeContext::init();
     Notification::new()
         .summary("Notify Rust Windows")
-        .appname("notify-rust windows")
-        .body("yay, we have windows support")
-        .icon("firefox")
+        .body("yay, we have limited windows support\nWith multiple lines\nSound\nBut no images")
         .show()
         .unwrap();
-    rt.uninit();
-
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,9 +2,6 @@
 #[cfg(all(unix, not(target_os = "macos")))]
 use dbus;
 
-#[cfg(target_os= "windows")]
-use winrt;
-
 #[cfg(target_os= "macos")]
 use mac_notification_sys;
 

--- a/tests/realworld.rs
+++ b/tests/realworld.rs
@@ -1,5 +1,4 @@
 #![allow(unused_must_use)]
-#![cfg(all(unix, not(target_os = "macos")))]
 extern crate notify_rust;
 
 #[cfg(test)]
@@ -46,7 +45,7 @@ fn burst()
     }
 }
 
-#[test]
+#[cfg(all(test, unix, not(target_os = "macos")))]
 fn closing()
 {
     Notification::new()
@@ -57,7 +56,7 @@ fn closing()
         .close();
 }
 
-#[test]
+#[cfg(all(test, unix, not(target_os = "macos")))]
 fn capabilities()
 {
     let capabilities:Vec<String> = get_capabilities().unwrap();


### PR DESCRIPTION
Work towards resolving #37
This adds text and sound (as much as windows toasts can have sound) notifications for windows.

The changes to the tests might break tests on macos, not sure.

Images and icons are not exposed. Hints might be a good way to do that.