### PR TITLE
Complement requirements documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,14 @@ notify-rust = "3"
 * macos
 * no windows support
 
+## Compiletime requirements
+
+* `libdbus-1-dev`
+
 # Examples
 ## Example 1 (Simple Notification)
 ```rust
+extern crate notify_rust;
 use notify_rust::Notification;
 Notification::new()
     .summary("Firefox News")
@@ -38,6 +43,7 @@ Notification::new()
 
 ## Example 2 (Persistent Notification)
 ```rust
+extern crate notify_rust;
 use notify_rust::Notification;
 use notify_rust::NotificationHint as Hint;
 Notification::new()


### PR DESCRIPTION
The documentation missed the compiletime requirement `libdbus-1-dev`.

When using this crate without having `libdbus-1-dev` installed, `cargo build` fails with the following error message on a linux system:

```
error: failed to run custom build command for `dbus v0.4.1`
process didn't exit successfully: `[…]target/debug/build/dbus-17d90d6172f41386/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "`\"pkg-config\" \"--libs\" \"--cflags\" \"dbus-1\"` did not exit successfully: exit code: 1\n--- stderr\nPackage dbus-1 was not found in the pkg-config search path.\nPerhaps you should add the directory containing `dbus-1.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'dbus-1\' found\n"', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```

Additionally, the examples missed `external create notify_rust;`. `cargo build` fails with the following message in that case:

```
1 | use notify_rust::Notification;
  |     ^^^^^^^^^^^ Maybe a missing `extern crate notify_rust;`?
```