### PR TITLE
images features now depends on lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ mac-notification-sys = "0.3"
 [features]
 default = []
 debug_namespace = []
-images = ["image"]
+images = ["image", "lazy_static"]

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -269,7 +269,7 @@ impl<'a> From<&'a NotificationHint> for MessageItem {
             NotificationHint::Category(ref value)      => (CATEGORY       .to_owned(), MessageItem::Str(value.clone())),
             NotificationHint::DesktopEntry(ref value)  => (DESKTOP_ENTRY  .to_owned(), MessageItem::Str(value.clone())),
             #[cfg(all(feature = "images", unix, not(target_os ="macos")))]
-            NotificationHint::ImageData(ref image)     => (image_spec(*::SPEC_VERSION), image.clone().into()),
+            NotificationHint::ImageData(ref image)     => (image_spec(*crate::SPEC_VERSION), image.clone().into()),
             NotificationHint::ImagePath(ref value)     => (IMAGE_PATH     .to_owned(), MessageItem::Str(value.clone())),
             NotificationHint::Resident(value)          => (RESIDENT       .to_owned(), MessageItem::Bool(value)), // bool
             NotificationHint::SoundFile(ref value)     => (SOUND_FILE     .to_owned(), MessageItem::Str(value.clone())),


### PR DESCRIPTION
fixed compilation error for iamges example with debian

```   Compiling notify-rust v3.6.2 (/home/*/Dokumente/Rust/notify-rust)
error[E0464]: multiple matching crates for `lazy_static`
   --> src/lib.rs:163:1
    |
163 | extern crate lazy_static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: candidates:
            crate `lazy_static`: /home/*/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblazy_static-d66edcc18da7b065.rlib
            crate `lazy_static`: /home/*rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblazy_static-c786832e7e103fc8.rlib

error[E0463]: can't find crate for `lazy_static`
   --> src/lib.rs:163:1
    |
163 | extern crate lazy_static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0463`.
error: Could not compile `notify-rust`.

To learn more, run the command again with --verbose.
```