### PR TITLE
Add schedule support for macos notification

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -52,7 +52,7 @@ pub(crate) fn schedule_notification(notification: &Notification, delivery_date: 
         &notification.subtitle.as_ref().map(AsRef::as_ref),   // subtitle
         &notification.body,                                   // message
         &notification.sound_name.as_ref().map(AsRef::as_ref), // sound
-        delivery_date, // schedule_time
+        delivery_date,
     )?;
 
     Ok(NotificationHandle::new(notification.clone()))

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -37,10 +37,22 @@ impl DerefMut for NotificationHandle {
 
 pub(crate) fn show_notification(notification: &Notification) -> Result<NotificationHandle> {
     mac_notification_sys::send_notification(
-        &notification.summary,                                //title
+        &notification.summary,                                // title
         &notification.subtitle.as_ref().map(AsRef::as_ref),   // subtitle
-        &notification.body,                                   //message
+        &notification.body,                                   // message
         &notification.sound_name.as_ref().map(AsRef::as_ref), // sound
+    )?;
+
+    Ok(NotificationHandle::new(notification.clone()))
+}
+
+pub(crate) fn schedule_notification(notification: &Notification, delivery_date: f64) -> Result<NotificationHandle> {
+    mac_notification_sys::schedule_notification(
+        &notification.summary,                                // title
+        &notification.subtitle.as_ref().map(AsRef::as_ref),   // subtitle
+        &notification.body,                                   // message
+        &notification.sound_name.as_ref().map(AsRef::as_ref), // sound
+        delivery_date, // schedule_time
     )?;
 
     Ok(NotificationHandle::new(notification.clone()))

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -56,7 +56,7 @@ pub struct Notification {
 
     /// Use a file:// URI or a name in an icon theme, must be compliant freedesktop.org.
     pub icon:    String,
-    
+
     /// Check out `Hint`
     ///
     /// # warning

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -334,6 +334,13 @@ impl Notification {
         self.clone()
     }
 
+    /// Schedules a Notification
+    ///
+    /// Sends a Notification at the specified date
+    #[cfg(target_os = "macos")]
+    pub fn schedule(&self, delivery_date: f64) -> Result<macos::NotificationHandle> {
+        macos::schedule_notification(self, delivery_date)
+    }
 
     /// Sends Notification to D-Bus.
     ///


### PR DESCRIPTION
Hi, I've added scheduling support for macos. This feature is already present in the [mac-notification-sys](https://github.com/h4llow3En/mac-notification-sys/blob/2ee92b82478448f45f0c573e8852ea9ad9377d2d/src/notification.rs#L112) library.
Thought it was best not to add it as an attribute of `Notification` since this is only intended for macos, and that would've meant a far greater change that was not worth it in my opinion. Also since the `schedule` method receives a `f64` input, it adds legibility.

Tell me what you think, and if I have to make changes.

Cheers!

~Edit: Just seen the commit guidelines, will update pr.~