### PR TITLE
feat: add schedule_raw() for f64 timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.44.0
+          - 1.46.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 mac-notification-sys = "0.3"
+chrono = { version = "0.4", optional = true}
 
 [target.'cfg(target_os="windows")'.dependencies]
 winrt-notification = "0.2"
@@ -56,3 +57,8 @@ required-features = ["images"]
 name = "hints_server"
 path = "examples/hints_server.rs"
 required-features = ["server"]
+
+[[example]]
+name = "schedule"
+path = "examples/schedule.rs"
+required-features = ["chrono"]

--- a/examples/mac.rs
+++ b/examples/mac.rs
@@ -1,18 +1,12 @@
 #[cfg(target_os = "macos")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use notify_rust::{
-        get_bundle_identifier_or_default, set_application, Notification,
-    };
-
-    let safari_id = get_bundle_identifier_or_default("Safari");
-    set_application(&safari_id)?;
-    set_application(&safari_id)?;
+    use notify_rust::Notification;
 
     Notification::new()
         .summary("Safari Crashed")
         .body("Just kidding, this is just the notify_rust example.")
-        .appname("Safari")
-        .icon("Safari")
+        .appname("Toastify")
+        .icon("Toastify")
         .show()?;
 
     Ok(())

--- a/examples/schedule.rs
+++ b/examples/schedule.rs
@@ -1,0 +1,29 @@
+#[cfg(target_os = "macos")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use notify_rust::Notification;
+
+    let duration = chrono::Duration::milliseconds(4321);
+    let timestamp =  (chrono::Utc::now() + duration).timestamp() as f64;
+
+    Notification::new()
+        .summary("Oh by the way")
+        .body(&format!("this was scheduled {:?} ago", duration))
+        .schedule(chrono::Utc::now() + duration)?;
+
+    Notification::new()
+        .summary("Oh by the way")
+        .body(&format!("this was scheduled for timestamp {}", timestamp))
+        .schedule_raw(timestamp)?;
+
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn main() {
+    println!("this is a mac only feature")
+}
+
+#[cfg(windows)]
+fn main() {
+    println!("this is a mac only feature")
+}

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -173,10 +173,10 @@ pub(crate) fn hints_to_map(notification: &Notification) -> HashMap::<&str, zvari
 }
 
 #[cfg(all(feature = "zbus", unix, not(target_os = "macos")))]
-impl<'a> Into<(&'a str, zvariant::Value<'a>)> for &'a Hint {
-    fn into(self) -> (&'a str, zvariant::Value<'a>) {
+impl<'a> From<&'a Hint> for (&'a str, zvariant::Value<'a>) {
+    fn from(val: &'a Hint) -> Self {
         use self::constants::*;
-        match self {
+        match val {
             Hint::ActionIcons(value)       => (ACTION_ICONS   , zvariant::Value::Bool(*value)), // bool
             Hint::Category(value)          => (CATEGORY       , zvariant::Value::Str(value.as_str().into())),
             Hint::DesktopEntry(value)      => (DESKTOP_ENTRY  , zvariant::Value::Str(value.as_str().into())),

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -336,10 +336,20 @@ impl Notification {
 
     /// Schedules a Notification
     ///
-    /// Sends a Notification at the specified date
+    /// Sends a Notification at the specified date.
+    #[cfg(all(target_os = "macos", feature = "chrono"))]
+    pub fn schedule<T: chrono::TimeZone>(&self, delivery_date: chrono::DateTime<T>) -> Result<macos::NotificationHandle> {
+        macos::schedule_notification(self, delivery_date.timestamp() as f64)
+    }
+
+    /// Schedules a Notification
+    ///
+    /// Sends a Notification at the specified timestamp.
+    /// This is a raw `f64`, if that is a bit too raw for you please activate the feature `"chrono"`,
+    /// then you can use `Notification::schedule()` instead, which accepts a `chrno::DateTime<T>`.
     #[cfg(target_os = "macos")]
-    pub fn schedule(&self, delivery_date: f64) -> Result<macos::NotificationHandle> {
-        macos::schedule_notification(self, delivery_date)
+    pub fn schedule_raw(&self, timestamp: f64) -> Result<macos::NotificationHandle> {
+        macos::schedule_notification(self, timestamp)
     }
 
     /// Sends Notification to D-Bus.
@@ -359,7 +369,7 @@ impl Notification {
         macos::show_notification(self)
     }
 
-     /// Sends Notification to NSUserNotificationCenter.
+    /// Sends Notification to NSUserNotificationCenter.
     ///
     /// Returns an `Ok` no matter what, since there is currently no way of telling the success of
     /// the notification.

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -14,7 +14,7 @@ pub enum Timeout {
 }
 
 impl Timeout {
-    #[cfg(feature = "zbus")]
+    #[cfg(all(unix, not(target_os = "macos")))]
     pub(crate) fn into_i32(self) -> i32 {
         self.into()
     }
@@ -44,9 +44,9 @@ impl From<i32> for Timeout {
     }
 }
 
-impl Into<i32> for Timeout {
-    fn into(self) -> i32 {
-        match self {
+impl From<Timeout> for i32 {
+    fn from(timeout: Timeout) -> Self {
+        match timeout {
             Timeout::Default => -1,
             Timeout::Never => 0,
             Timeout::Milliseconds(ms) => ms as i32,


### PR DESCRIPTION
Hi @guillermoap,
I found the `Notification::schedule(delivery_date: f64)` to be a bit raw. So I took the liberty to rename it to `Notification::schedule_raw(timestamp: 64)` and added `Notification::schedule(dalivery_date: chrono:: DateTime)` instead.

check out https://github.com/hoodie/notify-rust/blob/feature/hendriks/schedule-raw/examples/schedule.rs

what do you think?