### PR TITLE
Downgrade zvariant_derive to make MSRV 1.46 again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.51.0
+          - 1.46.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -64,7 +64,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.51.0
+          - 1.46.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ dbus = { version = "0.9", optional = true }
 lazy_static = { version = "1", optional = true }
 image = { version = "0.23", optional = true }
 zvariant = { version = "2", optional = true }
-zvariant_derive = { version = "2", optional = true }
+zvariant_derive = { version = ">=2, <2.7", optional = true }
 zbus = { version = "1", optional = true }
 serde = { version = "1", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is functionally identical to the default feature set.
 
 |             | with dbus | with zbus|
 | ----------- | ---       |   ---    |
-| **`rustc`** | >= 1.51   |  >= 1.51 |
+| **`rustc`** | >= 1.46   |  >= 1.46 |
 | **libdbus** | **yes**   |  nope!   |
 
 ## macOS support


### PR DESCRIPTION
https://github.com/palfrey/notify-rust/actions/runs/1273105903 demos this working, as this would need #117 merged to build here.