### PR TITLE
Enables CI on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 name: Continuous Integration
 


### PR DESCRIPTION
It also disables it for branches other than main, as that avoids double-builds when they've also got a PR