### PR TITLE
Update winrt-notification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = [
   "LICENSE-*",
   "Cargo.toml",
   "src/**/*.rs",
-  "tests/*.rs"
+  "tests/*.rs",
 ]
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
@@ -30,10 +30,10 @@ serde = { version = "1", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 mac-notification-sys = "0.3"
-chrono = { version = "0.4", optional = true}
+chrono = { version = "0.4", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
-winrt-notification = "0.2"
+winrt-notification = "0.4"
 
 [features]
 default = ["z"]


### PR DESCRIPTION
We are using cargo deny in our monorepo to lint our dependencies and and winrt-notification was pulling on outdated dependencies, an update was made on their repo that let to incrementing the minor version. This PR updates winrt-notification to the newly released version.