### PR TITLE
Bump the winrt-notification version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ mac-notification-sys = "0.3"
 chrono = { version = "0.4", optional = true}
 
 [target.'cfg(target_os="windows")'.dependencies]
-winrt-notification = "0.4"
+winrt-notification = "0.5"
 
 [features]
 default = ["z"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,40 +81,40 @@
 //! ❌ = will not compile
 //! 
 //! ## `Notification`
-//! | method              | XDG   | macOS |
-//! |---------------------|-------|-------|
-//! |  `fn appname(...)`  |  ✔︎    |       |
-//! |  `fn summary(...)`  |  ✔︎    | ✔︎     |
-//! |  `fn subtitle(...)` |       | ✔︎     |
-//! |  `fn body(...)`     |  ✔︎    | ✔︎     |
-//! |  `fn icon(...)`     |  ✔︎    |       |
-//! |  `fn auto_icon(...)`|  ✔︎    |       |
-//! |  `fn hint(...)`     |  ✔︎    | ❌    |
-//! |  `fn timeout(...)`  |  ✔︎    |       |
-//! |  `fn urgency(...)`  |  ✔︎    | ❌    |
-//! |  `fn action(...)`   |  ✔︎    |       |
-//! |  `fn id(...)`       |  ✔︎    |       |
-//! |  `fn finalize(...)` |  ✔︎    | ✔︎     |
-//! |  `fn show(...)`     |  ✔︎    | ✔︎     |
+//! | method              | XDG   | macOS | windows |
+//! |---------------------|-------|-------|---------|
+//! |  `fn appname(...)`  |  ✔︎    |       |        |
+//! |  `fn summary(...)`  |  ✔︎    | ✔︎     |  ✔︎    |
+//! |  `fn subtitle(...)` |       | ✔︎     |  ✔︎    |
+//! |  `fn body(...)`     |  ✔︎    | ✔︎     |  ✔︎    |
+//! |  `fn icon(...)`     |  ✔︎    |       |        |
+//! |  `fn auto_icon(...)`|  ✔︎    |       |        |
+//! |  `fn hint(...)`     |  ✔︎    | ❌    | ❌    |
+//! |  `fn timeout(...)`  |  ✔︎    |       |  ✔︎    |
+//! |  `fn urgency(...)`  |  ✔︎    | ❌    | ❌    |
+//! |  `fn action(...)`   |  ✔︎    |       |        |
+//! |  `fn id(...)`       |  ✔︎    |       |        |
+//! |  `fn finalize(...)` |  ✔︎    | ✔︎     |  ✔︎    |
+//! |  `fn show(...)`     |  ✔︎    | ✔︎     |  ✔︎    |
 //!
 //! ## `NotificationHandle`
 //!
-//! | method                   | XDG | macOS |
-//! |--------------------------|-----|-------|
-//! | `fn wait_for_action(...)`|  ✔︎  |  ❌   |
-//! | `fn close(...)`          |  ✔︎  |  ❌   |
-//! | `fn on_close(...)`       |  ✔︎  |  ❌   |
-//! | `fn update(...)`         |  ✔︎  |  ❌   |
-//! | `fn id(...)`             |  ✔︎  |  ❌   |
+//! | method                   | XDG | macOS | windows |
+//! |--------------------------|-----|-------|---------|
+//! | `fn wait_for_action(...)`|  ✔︎  |  ❌  |   ❌   |
+//! | `fn close(...)`          |  ✔︎  |  ❌  |   ❌   |
+//! | `fn on_close(...)`       |  ✔︎  |  ❌  |   ❌   |
+//! | `fn update(...)`         |  ✔︎  |  ❌  |   ❌   |
+//! | `fn id(...)`             |  ✔︎  |  ❌  |   ❌   |
 //!
 //! ## Functions
 //!
-//! |                                            | XDG | macOS |
-//! |--------------------------------------------|-----|-------|
-//! | `fn get_capabilities(...)`                 | ✔︎   |    ❌ |
-//! | `fn get_server_information(...)`           | ✔︎   |    ❌ |
-//! | `fn set_application(...)`                  | ❌  |    ✔︎  |
-//! | `fn get_bundle_identifier_or_default(...)` | ❌  |    ✔︎  |
+//! |                                            | XDG | macOS | windows |
+//! |--------------------------------------------|-----|-------|---------|
+//! | `fn get_capabilities(...)`                 | ✔︎   |   ❌ |  ❌    |
+//! | `fn get_server_information(...)`           | ✔︎   |   ❌ |  ❌    |
+//! | `fn set_application(...)`                  | ❌  |   ✔︎  |  ❌    |
+//! | `fn get_bundle_identifier_or_default(...)` | ❌  |   ✔︎  |  ❌    |
 //!
 //!
 //! ### Toggles


### PR DESCRIPTION
A little soon after the previous one but this adds support for the `windows-gnu` targets without having to install mingw.

No change in the number of passing tests/compiling examples. (hint/urgency methods don't compile, removing those calls makes the examples compile but this is expected)
Same number of notifications are created by test runs.
The platform differences table looks right in the generated docs.

This kinda duplicates https://github.com/hoodie/notify-rust/pull/125, but has some manual testing and an update to the documentation.