### PR TITLE
Upgrade zbus, zvariant, vzariant_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = { version = "1", optional = true }
 image = { version = "0.23", optional = true }
 zvariant = { version = "2", optional = true }
 zvariant_derive = { version = "2", optional = true }
-zbus = { version = "1", optional = true }
+zbus = { version = "2", optional = true }
 serde = { version = "1", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ include = [
 dbus = { version = "0.9", optional = true }
 lazy_static = { version = "1", optional = true }
 image = { version = "0.23", optional = true }
-zvariant = { version = "2", optional = true }
-zvariant_derive = { version = "2", optional = true }
+zvariant = { version = "3", optional = true }
+zvariant_derive = { version = "3", optional = true }
 zbus = { version = "2", optional = true }
 serde = { version = "1", optional = true }
 

--- a/src/xdg/mod.rs
+++ b/src/xdg/mod.rs
@@ -51,7 +51,7 @@ impl NotificationHandle {
     }
 
     #[cfg(feature = "zbus")]
-    pub(crate) fn for_zbus(id: u32, connection: zbus::Connection, notification: Notification) -> NotificationHandle {
+    pub(crate) fn for_zbus(id: u32, connection: zbus::blocking::Connection, notification: Notification) -> NotificationHandle {
         NotificationHandle {
             inner: zbus_rs::ZbusNotificationHandle::new(id, connection, notification).into(),
         }

--- a/src/xdg/zbus_rs.rs
+++ b/src/xdg/zbus_rs.rs
@@ -1,5 +1,5 @@
 use crate::{error::*, notification::Notification, xdg};
-use zbus::Connection;
+use zbus::blocking::Connection;
 
 use super::{ActionResponse, ActionResponseHandler, CloseReason};
 
@@ -78,14 +78,14 @@ pub fn send_notificaion_via_connection(notification: &Notification, id: u32, con
 }
 
 pub fn connect_and_send_notification(notification: &Notification) -> Result<ZbusNotificationHandle> {
-    let connection = zbus::Connection::new_session()?;
+    let connection = zbus::blocking::Connection::session()?;
     let inner_id = notification.id.unwrap_or(0);
     let id = send_notificaion_via_connection(notification, inner_id, &connection)?;
     Ok(ZbusNotificationHandle::new(id, connection, notification.clone()))
 }
 
 pub fn get_capabilities() -> Result<Vec<String>> {
-    let connection = zbus::Connection::new_session()?;
+    let connection = zbus::blocking::Connection::session()?;
     let info: Vec<String> = connection
         .call_method(
             Some(crate::xdg::NOTIFICATION_NAMESPACE),
@@ -101,7 +101,7 @@ pub fn get_capabilities() -> Result<Vec<String>> {
 }
 
 pub fn get_server_information() -> Result<xdg::ServerInformation> {
-    let connection = zbus::Connection::new_session()?;
+    let connection = zbus::blocking::Connection::session()?;
     let info: xdg::ServerInformation = connection
         .call_method(
             Some(crate::xdg::NOTIFICATION_NAMESPACE),
@@ -120,12 +120,12 @@ pub fn get_server_information() -> Result<xdg::ServerInformation> {
 ///
 /// No need to use this, check out `Notification::show_and_wait_for_action(FnOnce(action:&str))`
 pub fn handle_action(id: u32, func: impl ActionResponseHandler) {
-    let mut connection = Connection::new_session().unwrap();
+    let mut connection = Connection::session().unwrap();
     wait_for_action_signal(&mut connection, id, func);
 }
 
-fn wait_for_action_signal(connection: &mut Connection, id: u32, handler: impl ActionResponseHandler) {
-    let proxy = zbus::fdo::DBusProxy::new(connection).unwrap();
+fn wait_for_action_signal(connection: &Connection, id: u32, handler: impl ActionResponseHandler) {
+    let proxy = zbus::blocking::fdo::DBusProxy::new(connection).unwrap();
     proxy
         .add_match("interface='org.freedesktop.Notifications',member='ActionInvoked'")
         .unwrap();
@@ -133,27 +133,34 @@ fn wait_for_action_signal(connection: &mut Connection, id: u32, handler: impl Ac
         .add_match("interface='org.freedesktop.Notifications',member='NotificationClosed'")
         .unwrap();
 
-    while let Ok(msg) = connection.receive_message() {
-        if let Ok(header) = msg.header() {
-            if let Ok(zbus::MessageType::Signal) = header.message_type() {
-                match header.member() {
-                    Ok(Some("ActionInvoked")) => match msg.body::<(u32, String)>() {
-                        Ok((nid, action)) if nid == id => {
-                            handler.call(&ActionResponse::Custom(&action));
-                            break;
+    let mut msg_iter = zbus::blocking::MessageIterator::from(connection);
+    while let Some(msg) = msg_iter.next() {
+        if let Ok(msg) = msg {
+            if let Ok(header) = msg.header() {
+                if let Ok(zbus::MessageType::Signal) = header.message_type() {
+                    match header.member() {
+                        Ok(Some(name)) => {
+                            if name == &zbus::names::MemberName::from_static_str("ActionInvoked").unwrap() {
+                                match msg.body::<(u32, String)>() {
+                                    Ok((nid, action)) if nid == id => {
+                                        handler.call(&ActionResponse::Custom(&action));
+                                        break;
+                                    }
+                                    _ => {}
+                                }
+                            } else if name == &zbus::names::MemberName::from_static_str("NotificationClosed").unwrap() {
+                                match msg.body::<(u32, u32)>() {
+                                    Ok((nid, reason)) if nid == id => {
+                                        handler.call(&ActionResponse::Closed(reason.into()));
+                                        break;
+                                    }
+                                    _ => {}
+                                }
+                            }
                         }
-                        _ => {}
-                    },
-                    Ok(Some("NotificationClosed")) => match msg.body::<(u32, u32)>() {
-                        Ok((nid, reason)) if nid == id => {
-                            handler.call(&ActionResponse::Closed(reason.into()));
-                            break;
-                        }
-                        _ => {}
-                    },
-
-                    Ok(_) => {}
-                    Err(_) => {}
+                        Ok(_) => {}
+                        Err(_) => {}
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hey there,
Thanks for the great library! I recently noticed that an older dependency of your lib caused some problems for FreeBSD users of my project, so I took the freedom to upgrade it. Let me know if there are any problems and I'll fix them as soon as I can.

Instead of using the new async/await capabilities of zbus, I opted for
the blocking version, since it was the least invasive change and the
original was designed around blocking code.
The biggest change was the way notifications are received. In the v2 api
they are only accessible via an iterator.
A small inconvenience of the new api is the wrapping of the member name
that makes using matches difficult.

Closes #131 #130 #129 