### PR TITLE
fix: re-exported types from mac-notification-sys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 .directory
 *.rustfmt
 *.rsx
+main-doc

--- a/examples/mac_app_id.rs
+++ b/examples/mac_app_id.rs
@@ -1,13 +1,15 @@
 #[cfg(target_os = "macos")]
 fn main() -> Result<(), String> {
-    use notify_rust::{
-        get_bundle_identifier_or_default, set_application, Notification,
-    };
+    use notify_rust::{error::MacOsError, get_bundle_identifier_or_default, set_application, Notification};
 
     let safari_id = get_bundle_identifier_or_default("Safari");
     set_application(&safari_id).map_err(|f| format!("{}", f))?;
 
-    set_application(&safari_id).map_err(|f| format!("{}", f))?;
+    match set_application(&safari_id) {
+        Ok(_) => {}
+        Err(MacOsError::Application(error)) => println!("{}", error),
+        Err(MacOsError::Notification(error)) => println!("{}", error),
+    }
 
     Notification::new()
         .summary("Safari Crashed")

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,9 @@ use std::{fmt, num};
 /// Convenient wrapper around `std::Result`.
 pub type Result<T> = ::std::result::Result<T, Error>;
 
+#[cfg(target_os = "macos")]
+pub use crate::macos::{ApplicationError, MacOsError, NotificationError};
+
 /// The Error type.
 #[derive(Debug)]
 pub struct Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ mod notification;
 pub(crate) mod urgency;
 
 #[cfg(target_os = "macos")] pub use mac_notification_sys::{get_bundle_identifier_or_default, set_application};
-#[cfg(target_os = "macos")] pub use macos::*;
+#[cfg(target_os = "macos")] pub use macos::NotificationHandle;
 
 #[cfg(all(any(feature = "dbus", feature = "zbus"), unix, not(target_os = "macos")))]
 pub use crate::xdg::{

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,7 @@
-pub use crate::{error::*, notification::Notification};
+use crate::{error::*, notification::Notification};
+
+pub use mac_notification_sys::error::{Error as MacOsError, NotificationError,ApplicationError};
+
 
 use std::ops::{Deref, DerefMut};
 


### PR DESCRIPTION
Addressing #138, seems we accidentally reexported the wrong types on macos, but not the ones we need.