### PR TITLE
feat: update winrt-notification to a maintained fork, closes #148

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ mac-notification-sys = "0.5.0"
 chrono = { version = "0.4", optional = true}
 
 [target.'cfg(target_os="windows")'.dependencies]
-winrt-notification = "0.5"
+winrt-notification = { package = "tauri-winrt-notification", version = "0.1" }
 
 [features]
 default = ["z"]


### PR DESCRIPTION
This PR updates the `winrt-notification` dependency to use [tauri-winrt-notification](https://github.com/tauri-apps/winrt-notification), a fork we will maintain until the original author is able to fix a security [vulnerability](https://rustsec.org/advisories/RUSTSEC-2022-0008.html) that exists because of an outdated windows version.

This fork updates the windows dependency to 0.39.0, which requires Rust 1.59.0. Other operating systems are not affected by it so that's why I kept the original MSRV in the Cargo manifest.