### PR TITLE
Implement FromStr for Timeout

### DIFF
--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,3 +1,5 @@
+use std::{num::ParseIntError, str::FromStr};
+
 /// Describes the timeout of a notification
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Timeout {
@@ -51,6 +53,18 @@ impl From<Timeout> for i32 {
             Timeout::Default => -1,
             Timeout::Never => 0,
             Timeout::Milliseconds(ms) => ms as i32,
+        }
+    }
+}
+
+impl FromStr for Timeout {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(Timeout::Default),
+            "never" => Ok(Timeout::Never),
+            milliseconds => Ok(Timeout::Milliseconds(u32::from_str(milliseconds)?)),
         }
     }
 }

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,6 +1,15 @@
 use std::{num::ParseIntError, str::FromStr};
 
 /// Describes the timeout of a notification
+/// 
+/// # `FromStr`
+/// You can also parse a `Timeout` from a `&str`.
+/// ```
+/// # use notify_rust::Timeout;
+/// assert_eq!("default".parse(), Ok(Timeout::Default));
+/// assert_eq!("never".parse(), Ok(Timeout::Never));
+/// assert_eq!("42".parse(), Ok(Timeout::Milliseconds(42)));
+/// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Timeout {
     /// Expires according to server default.

--- a/src/xdg/mod.rs
+++ b/src/xdg/mod.rs
@@ -302,7 +302,7 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<Notificat
     }
 }
 
-/// Get the currently dsed [`DbusStack`]
+/// Get the currently used [`DbusStack`]
 ///
 /// (zbus only)
 #[cfg(all(feature = "zbus", not(feature = "dbus")))]
@@ -310,7 +310,7 @@ pub fn dbus_stack() -> Option<DbusStack> {
     Some(DbusStack::Zbus)
 }
 
-/// Get the currently dsed [`DbusStack`]
+/// Get the currently used [`DbusStack`]
 ///
 /// (dbus-rs only)
 #[cfg(all(feature = "dbus", not(feature = "zbus")))]
@@ -318,7 +318,7 @@ pub fn dbus_stack() -> Option<DbusStack> {
     Some(DbusStack::Dbus)
 }
 
-/// Get the currently dsed [`DbusStack`]
+/// Get the currently used [`DbusStack`]
 ///
 /// both dbus-rs and zbus, switch via `$ZBUS_NOTIFICATION`
 #[cfg(all(feature = "dbus", feature = "zbus"))]
@@ -330,7 +330,7 @@ pub fn dbus_stack() -> Option<DbusStack> {
     })
 }
 
-/// Get the currently dsed [`DbusStack`]
+/// Get the currently used [`DbusStack`]
 ///
 /// neither zbus nor dbus-rs are configured
 #[cfg(all(not(feature = "dbus"), not(feature = "zbus")))]


### PR DESCRIPTION
Useful when wanting to pass it as a command line argument to an application.

I recently needed to pass the notification timeout on the command line. I ended up implementing a custom function, but thought maybe it would be a nice addition:

See https://github.com/rnestler/reboot-arch-btw/pull/106/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR18-R25

If you think this is a good thing, then I'd of course also add tests and whatever else you think is necessary.