### PR TITLE
fix: remove redundant action button on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.64.0
+          - 1.67.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -55,7 +55,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.64.0
+          - 1.67.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -97,7 +97,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.64.0
+          - 1.67.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -132,7 +132,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.64.0
+          - 1.67.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -241,7 +241,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.63.0
+          - 1.67.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4"
 env_logger ={ version ="0.10", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
-mac-notification-sys = "0.5"
+mac-notification-sys = "0.6"
 chrono = { version = "0.4", optional = true}
 
 [target.'cfg(target_os="windows")'.dependencies]
@@ -46,8 +46,8 @@ debug_namespace = []
 images = ["image", "lazy_static"]
 
 [dev-dependencies]
-color-backtrace = "0.5"
-ctor = "0.1"
+color-backtrace = "0.5" # wait for MSVR 1.70 to update
+ctor = "0.2"
 maplit = "1.0"
 
 [dev-dependencies.async-std]


### PR DESCRIPTION
On macOS we would always show a redundant "Show" button, this is now fixed in https://github.com/h4llow3En/mac-notification-sys/releases/tag/v0.6.0