### PR TITLE
Add feature `d_vendored` to enable dbus/vendored feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ winrt-notification = { package = "tauri-winrt-notification", version = "0.1" }
 default = ["z"]
 #`server = []
 d = ["dbus"]
+d_vendored = ["dbus/vendored"]
 z = ["zbus", "serde", "async"]
 async = []
 debug_namespace = []


### PR DESCRIPTION
[This feature allows static linking][1].

[1]: https://github.com/diwic/dbus-rs/blob/master/libdbus-sys/cross_compile.md