### PR TITLE
Implement notification listener for mac and windows

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,13 @@
         "Xfce",
         "ZBUS",
         "zvariant"
+    ],
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml",
+        "./Cargo.toml",
+        "./Cargo.toml",
+        "./Cargo.toml",
+        "./Cargo.toml",
+        "./Cargo.toml"
     ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ mac-notification-sys = "0.6"
 chrono = { version = "0.4", optional = true}
 
 [target.'cfg(target_os="windows")'.dependencies]
-winrt-notification = { package = "tauri-winrt-notification", version = "0.10.1" }
+winrt-notification = { package = "tauri-winrt-notification", version = "0.1" }
 
 [features]
 default = ["z"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 ]
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-dbus = { version = "0.9", optional = true }
+dbus = { version = "0.9.7", optional = true }
 lazy_static = { version = "1", optional = true }
 image = { version = "0.24", optional = true }
 zbus = { version = "3.10", optional = true }
@@ -34,7 +34,7 @@ mac-notification-sys = "0.6"
 chrono = { version = "0.4", optional = true}
 
 [target.'cfg(target_os="windows")'.dependencies]
-winrt-notification = { package = "tauri-winrt-notification", version = "0.1" }
+winrt-notification = { package = "tauri-winrt-notification", version = "0.10.1" }
 
 [features]
 default = ["z"]

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,0 +1,23 @@
+
+
+
+#[cfg(target_os="windows")]
+pub type NotificationListener = crate::windows::Listener;
+
+#[cfg(target_os="macos")]
+pub type NotificationListener = crate::macos::Listener;
+
+
+impl NotificationListener {
+    pub fn new() -> Result<NotificationListener> {
+        NotificationListener::new()
+    }
+
+
+    pub fn listen<F>(&self, handler: F) -> Result<()>
+    where
+        F: FnMut(NotificationTriggerDetails) + Send + 'static,
+    {
+        self.add_listener(Box::new(handler))
+    }
+}

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -452,6 +452,18 @@ impl Notification {
         windows::show_notification(self)
     }
 
+    /// Listen to the notications
+    #[cfg(target_os = "windows")]
+    pub fn listen(&self) -> Result<()> {
+        windows::listen_notification(self)
+    }
+
+    /// Listen to the notification
+    #[cfg(target_os = "macos")]
+    pub fn listen(&self) -> Result<xdg::NotificationHandle> {
+        macos::show_notification(self)
+    }
+
     /// Wraps show() but prints notification to stdout.
     #[cfg(all(unix, not(target_os = "macos")))]
     #[deprecated = "this was never meant to be public API"]

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -452,17 +452,6 @@ impl Notification {
         windows::show_notification(self)
     }
 
-    /// Listen to the notications
-    #[cfg(target_os = "windows")]
-    pub fn listen(&self) -> Result<()> {
-        windows::listen_notification(self)
-    }
-
-    /// Listen to the notification
-    #[cfg(target_os = "macos")]
-    pub fn listen(&self) -> Result<xdg::NotificationHandle> {
-        macos::show_notification(self)
-    }
 
     /// Wraps show() but prints notification to stdout.
     #[cfg(all(unix, not(target_os = "macos")))]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,8 +1,24 @@
 use winrt_notification::Toast;
 
-pub use crate::{error::*, notification::Notification, timeout::Timeout};
+pub use crate::{error::*, notification::Notification, timeout::Timeout,NotificationListener, NotificationTriggerDetails};
 
 use std::{path::Path, str::FromStr};
+
+pub(crate) fn listen_notification()-> Result<()> {
+    let listener = NotificationListener::new().unwrap();
+
+    listener.add_listener(Box::new(move |details: NotificationTriggerDetails| {
+        println!("Received notification: {:?}", details);
+
+        // TODO: Do something with the notification
+    }));
+
+    // Listener in a loop
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
 
 pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
     let sound = match &notification.sound_name {


### PR DESCRIPTION
## Description
This PR implements listeners for mac and windows. But doesn't handle the recieved notification. I will need further guidance for that.

# macOS
Used `org.freedesktop.Notifications` interface provided by the Notification Daemon (notify-osd).

# Windows
Used winrt-notification. 

## TODO
- [ ] Handle notifications.
- [ ] Test for listeners.