### PR TITLE
fix(deps): broken zbus export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ zbus = { version = "5", optional = true }
 serde = { version = "1", optional = true }
 log = "0.4"
 env_logger ={ version ="0.11", optional = true }
+futures-lite = { version = "2.6.0"}
 
 [target.'cfg(target_os="macos")'.dependencies]
 mac-notification-sys = "0.6"

--- a/src/xdg/zbus_rs.rs
+++ b/src/xdg/zbus_rs.rs
@@ -1,5 +1,6 @@
 use crate::{error::*, notification::Notification, xdg};
-use zbus::{export::futures_util::TryStreamExt, MatchRule};
+use futures_lite::stream::StreamExt;
+use zbus::MatchRule;
 
 use super::{bus::NotificationBus, ActionResponse, ActionResponseHandler, CloseReason};
 


### PR DESCRIPTION
Fix https://github.com/hoodie/notify-rust/issues/236

I took the approach of manually adding a dependency on `futures_lite` to get the same functionality from `futures_lite::stream::StreamExt` as the now-defunct `zbus::export::futures_util::TryStreamExt`.