### PR TITLE
fix: resolve type inference issue with u32::MAX conversion

### DIFF
--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -47,7 +47,7 @@ impl From<Duration> for Timeout {
     fn from(duration: Duration) -> Timeout {
         if duration.is_zero() {
             Timeout::Never
-        } else if duration.as_millis() > u32::MAX.into() {
+        } else if duration.as_millis() as u128 > u32::MAX as u128 {
             Timeout::Default
         } else {
             Timeout::Milliseconds(duration.as_millis().try_into().unwrap_or(u32::MAX))

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -47,7 +47,7 @@ impl From<Duration> for Timeout {
     fn from(duration: Duration) -> Timeout {
         if duration.is_zero() {
             Timeout::Never
-        } else if duration.as_millis() as u128 > u32::MAX as u128 {
+        } else if duration.as_millis() > u32::MAX as u128 {
             Timeout::Default
         } else {
             Timeout::Milliseconds(duration.as_millis().try_into().unwrap_or(u32::MAX))


### PR DESCRIPTION
Explicitly cast `as_millis()` result to `u128` to avoid type inference error. This fixes compilation failure in `notify-rust` related to `PartialOrd` trait ambiguity when comparing `duration.as_millis()` with `u32::MAX.into()`.

Refs: rust-lang/rust#E0283