### PR TITLE
feat: add `z-with-tokio` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 dbus = { version = "0.9", optional = true }
 lazy_static = { version = "1.5", optional = true }
 image = { version = "0.25", optional = true }
-zbus = { version = "5", optional = true }
+zbus = { version = "5", optional = true, default-features = false }
 serde = { version = "1", optional = true }
 log = "0.4"
 env_logger ={ version ="0.11", optional = true }
@@ -43,7 +43,9 @@ default = ["z"]
 d = ["dbus"]
 d_vendored = ["dbus/vendored"]
 z = ["zbus", "serde", "async"]
-async = []
+z-with-tokio = ["zbus", "serde", "tokio"]
+async = ["zbus/async-io"]
+tokio = ["zbus/tokio"]
 debug_namespace = []
 images = ["image", "lazy_static"]
 


### PR DESCRIPTION
To make build `notify-rust` without `async-io` as optional