### PR TITLE
refactor: use `std::sync::LazyLock` to replace `lazy_static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ async = ["zbus/async-io"]
 tokio = ["zbus/tokio"]
 debug_namespace = []
 images = ["image"]
+lazy_static= [] # inert, here for backward compait, remove with next breaking change
 
 [dev-dependencies]
 color-backtrace = "0.7" # wait for MSVR 1.70 to update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ include = [
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 dbus = { version = "0.9", optional = true }
-lazy_static = { version = "1.5", optional = true }
 image = { version = "0.25", optional = true }
 zbus = { version = "5", optional = true, default-features = false }
 serde = { version = "1", optional = true }
@@ -47,7 +46,7 @@ z-with-tokio = ["zbus", "serde", "tokio"]
 async = ["zbus/async-io"]
 tokio = ["zbus/tokio"]
 debug_namespace = []
-images = ["image", "lazy_static"]
+images = ["image"]
 
 [dev-dependencies]
 color-backtrace = "0.7" # wait for MSVR 1.70 to update

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,10 +157,6 @@ extern crate mac_notification_sys;
 #[cfg(target_os = "windows")]
 extern crate winrt_notification;
 
-#[macro_use]
-#[cfg(all(feature = "images", unix, not(target_os = "macos")))]
-extern crate lazy_static;
-
 pub mod error;
 mod hints;
 mod miniver;
@@ -213,13 +209,13 @@ pub use crate::urgency::Urgency;
 pub use crate::{notification::Notification, timeout::Timeout};
 
 #[cfg(all(feature = "images", unix, not(target_os = "macos")))]
-lazy_static! {
-    /// Read once at runtime. Needed for Images
-    pub static ref SPEC_VERSION: miniver::Version =
-        get_server_information()
+/// Read once at runtime. Needed for Images
+pub static SPEC_VERSION: std::sync::LazyLock<miniver::Version> = std::sync::LazyLock::new(|| {
+    get_server_information()
         .and_then(|info| info.spec_version.parse::<miniver::Version>())
-        .unwrap_or_else(|_| miniver::Version::new(1,1));
-}
+        .unwrap_or_else(|_| miniver::Version::new(1, 1))
+});
+
 /// Return value of `get_server_information()`.
 #[derive(Debug)]
 pub struct ServerInformation {


### PR DESCRIPTION
Note that this modification raises the Rust version requirement to 1.80+

<!--
First and foremost, thank you for taking the time to contribute to this project! Your efforts are greatly appreciated.

## Semantic Commit Messages
Please ensure your commit messages follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/),
as these are being used to automatically generate the changelog and determine the version bump for releases.

Most importantly: [Mark breaking changes accordingly](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer)!

### Example
```
feat: add new user authentication module

fix: resolve issue with user not being able to login

feat!: remove deprecated user module
```
->>


Again, thank you for your contribution!
If you have any questions or need assistance, don't hesitate to ask. We're here to help!
