### PR TITLE
chore: slightly expand actions example

### DIFF
--- a/examples/actions.rs
+++ b/examples/actions.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
-use notify_rust::{Hint, Notification};
+use notify_rust::{Hint, Notification, Timeout};
 
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 fn main() {
@@ -10,10 +10,26 @@ fn main() {
 fn main() {
     Notification::new()
         .summary("click me")
+        .body("This will disappear by itself")
+        .action("clicked_a", "button a") // IDENTIFIER, LABEL
+        .hint(Hint::Transient(true)) // needed to work on kde
+        .show()
+        .unwrap()
+        .wait_for_action(|action| match action {
+            "clicked_a" => println!("clicked a"),
+            // FIXME: here "__closed" is a hardcoded keyword, it will be deprecated!!
+            "__closed" => println!("the notification was closed"),
+            _ => (),
+        });
+
+    Notification::new()
+        .summary("click me")
+        .body("This action needs to be clicked")
         .action("default", "default") // IDENTIFIER, LABEL
         .action("clicked_a", "button a") // IDENTIFIER, LABEL
         .action("clicked_b", "button b") // IDENTIFIER, LABEL
-        .hint(Hint::Resident(true))
+        .hint(Hint::Resident(true)) // does not work on kde
+        .timeout(Timeout::Never) // works on kde and gnome
         .show()
         .unwrap()
         .wait_for_action(|action| match action {


### PR DESCRIPTION
This PR improves the `actions.rs` example by
* making it work correctly on kde / gnome
* adding a second notification highlighting the need for `Hint::Transient(true)` #6