### PR TITLE
fix(zbus): don't unwrap result of close_fallible

### DIFF
--- a/src/xdg/zbus_rs.rs
+++ b/src/xdg/zbus_rs.rs
@@ -95,7 +95,7 @@ impl ZbusNotificationHandle {
     }
 
     pub async fn close(self) {
-        self.close_fallible().await.unwrap();
+        let _ = self.close_fallible().await;
     }
 
     pub fn on_close<F>(self, closure: F)


### PR DESCRIPTION
This would cause a panic when attempting to close a notification that has already been closed by the user manually since the ID we would then attempt to close is no longer valid. Reproducable with the `fnott` notification daemon.

Closes #253

<!--
First and foremost, thank you for taking the time to contribute to this project! Your efforts are greatly appreciated.

## Semantic Commit Messages
Please ensure your commit messages follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/),
as these are being used to automatically generate the changelog and determine the version bump for releases.

Most importantly: [Mark breaking changes accordingly](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer)!

### Example
```
feat: add new user authentication module

fix: resolve issue with user not being able to login

feat!: remove deprecated user module
```
->>


Again, thank you for your contribution!
If you have any questions or need assistance, don't hesitate to ask. We're here to help!
