### PR TITLE
feat: change the signature of on_close to no longer consume the handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license = "MIT/Apache-2.0"
 keywords = ["desktop", "notification", "notify", "linux", "macos"]
 readme = "README.md"
 include = [
-  "README.md",
-  "History.md",
-  "CHANGELOG.md",
-  "LICENSE-*",
-  "Cargo.toml",
-  "src/**/*.rs",
-  "tests/*.rs"
+    "README.md",
+    "History.md",
+    "CHANGELOG.md",
+    "LICENSE-*",
+    "Cargo.toml",
+    "src/**/*.rs",
+    "tests/*.rs",
 ]
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
@@ -27,12 +27,12 @@ image = { version = "0.25", optional = true }
 zbus = { version = "5", optional = true, default-features = false }
 serde = { version = "1", optional = true }
 log = "0.4"
-env_logger ={ version ="0.11", optional = true }
-futures-lite = { version = "2.6.0"}
+env_logger = { version = "0.11", optional = true }
+futures-lite = { version = "2.6.1" }
 
 [target.'cfg(target_os="macos")'.dependencies]
 mac-notification-sys = "0.6"
-chrono = { version = "0.4", optional = true}
+chrono = { version = "0.4", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 winrt-notification = { package = "tauri-winrt-notification", version = "0.7" }
@@ -55,7 +55,7 @@ ctor = "0.8"
 maplit = "1.0"
 
 [dev-dependencies.async-std]
-version = "1.12.0"
+version = "1.13.2"
 features = ["attributes"]
 
 [[example]]
@@ -77,6 +77,3 @@ required-features = ["async"]
 name = "simple_async"
 path = "examples/simple_async.rs"
 required-features = ["async"]
-
-[dependencies]
-futures-lite = "2.6.0"

--- a/examples/on_close.rs
+++ b/examples/on_close.rs
@@ -25,7 +25,8 @@ fn main() {
             .body("This will go away.")
             .icon("clock")
             .show()
-            .map(|handler| handler.on_close(print))
+            .unwrap()
+            .on_close(print);
     });
     wait_for_keypress();
 }

--- a/examples/on_close_reason.rs
+++ b/examples/on_close_reason.rs
@@ -27,7 +27,8 @@ fn main() {
             .body("This will go away.")
             .icon("clock")
             .show()
-            .map(|handler| handler.on_close(print_reason))
+            .unwrap()
+            .on_close(print_reason);
     });
     wait_for_keypress();
 }

--- a/src/xdg/dbus_rs.rs
+++ b/src/xdg/dbus_rs.rs
@@ -87,7 +87,7 @@ impl DbusNotificationHandle {
         }
     }
 
-    pub fn wait_for_action(self, invocation_closure: impl ActionResponseHandler) {
+    pub fn wait_for_action(&self, invocation_closure: impl ActionResponseHandler) {
         wait_for_action_signal(&self.connection, self.id, invocation_closure);
     }
 
@@ -97,7 +97,7 @@ impl DbusNotificationHandle {
         let _ = self.connection.send(message); // If closing fails there's nothing we could do anyway
     }
 
-    pub fn on_close<F>(self, closure: F)
+    pub fn on_close<F>(&self, closure: F)
     where
         F: FnOnce(CloseReason),
     {

--- a/src/xdg/mod.rs
+++ b/src/xdg/mod.rs
@@ -169,8 +169,8 @@ impl NotificationHandle {
     ///                    .unwrap()
     ///                    .on_close(|reason| println!("closed: {:?}", reason));
     /// ```
-    pub fn on_close<A>(self, handler: impl CloseHandler<A>) {
-        match self.inner {
+    pub fn on_close<A>(&self, handler: impl CloseHandler<A>) {
+        match &self.inner {
             #[cfg(feature = "dbus")]
             NotificationHandleInner::Dbus(inner) => {
                 inner.wait_for_action(|action: &ActionResponse| {

--- a/src/xdg/zbus_rs.rs
+++ b/src/xdg/zbus_rs.rs
@@ -77,7 +77,7 @@ impl ZbusNotificationHandle {
         }
     }
 
-    pub async fn wait_for_action(self, invocation_closure: impl ActionResponseHandler) {
+    pub async fn wait_for_action(&self, invocation_closure: impl ActionResponseHandler) {
         wait_for_action_signal(&self.connection, self.id, invocation_closure).await;
     }
 
@@ -98,7 +98,7 @@ impl ZbusNotificationHandle {
         let _ = self.close_fallible().await;
     }
 
-    pub fn on_close<F>(self, closure: F)
+    pub fn on_close<F>(&self, closure: F)
     where
         F: FnOnce(CloseReason),
     {


### PR DESCRIPTION
Refactors the notification handler API to use shared references (`&self`) instead of value receivers (`self`) for several methods, improving ergonomics and consistency.