### PR TITLE
Return Result from handle_action instead of panicking on D-Bus errors

### DIFF
--- a/src/xdg/dbus_rs.rs
+++ b/src/xdg/dbus_rs.rs
@@ -87,8 +87,8 @@ impl DbusNotificationHandle {
         }
     }
 
-    pub fn wait_for_action(self, invocation_closure: impl ActionResponseHandler) {
-        wait_for_action_signal(&self.connection, self.id, invocation_closure);
+    pub fn wait_for_action(self, invocation_closure: impl ActionResponseHandler) -> Result<()> {
+        wait_for_action_signal(&self.connection, self.id, invocation_closure)
     }
 
     pub fn close(self) {
@@ -97,7 +97,7 @@ impl DbusNotificationHandle {
         let _ = self.connection.send(message); // If closing fails there's nothing we could do anyway
     }
 
-    pub fn on_close<F>(self, closure: F)
+    pub fn on_close<F>(self, closure: F) -> Result<()>
     where
         F: FnOnce(CloseReason),
     {
@@ -105,7 +105,7 @@ impl DbusNotificationHandle {
             if let ActionResponse::Closed(reason) = action {
                 closure(*reason);
             }
-        });
+        })
     }
 
     pub fn update(&mut self) {
@@ -257,25 +257,25 @@ pub fn get_server_information() -> Result<ServerInformation> {
 /// Listens for the `ActionInvoked(UInt32, String)` Signal.
 ///
 /// No need to use this, check out `Notification::show_and_wait_for_action(FnOnce(action:&str))`
-pub fn handle_action(id: u32, func: impl ActionResponseHandler) {
-    let connection = Connection::get_private(BusType::Session).unwrap();
-    wait_for_action_signal(&connection, id, func);
+pub fn handle_action(id: u32, func: impl ActionResponseHandler) -> Result<()> {
+    let connection = Connection::get_private(BusType::Session)?;
+    wait_for_action_signal(&connection, id, func)
 }
 
 // Listens for the `ActionInvoked(UInt32, String)` signal.
-fn wait_for_action_signal(connection: &Connection, id: u32, handler: impl ActionResponseHandler) {
-    connection
-        .add_match(&format!(
-            "interface='{}',member='ActionInvoked'",
-            NOTIFICATION_INTERFACE
-        ))
-        .unwrap();
-    connection
-        .add_match(&format!(
-            "interface='{}',member='NotificationClosed'",
-            NOTIFICATION_INTERFACE
-        ))
-        .unwrap();
+fn wait_for_action_signal(
+    connection: &Connection,
+    id: u32,
+    handler: impl ActionResponseHandler,
+) -> Result<()> {
+    connection.add_match(&format!(
+        "interface='{}',member='ActionInvoked'",
+        NOTIFICATION_INTERFACE
+    ))?;
+    connection.add_match(&format!(
+        "interface='{}',member='NotificationClosed'",
+        NOTIFICATION_INTERFACE
+    ))?;
 
     for item in connection.iter(1000) {
         if let ConnectionItem::Signal(message) = item {
@@ -325,4 +325,5 @@ fn wait_for_action_signal(connection: &Connection, id: u32, handler: impl Action
             }
         }
     }
+    Ok(())
 }

--- a/src/xdg/mod.rs
+++ b/src/xdg/mod.rs
@@ -100,7 +100,7 @@ impl NotificationHandle {
         match self.inner {
             #[cfg(feature = "dbus")]
             NotificationHandleInner::Dbus(inner) => {
-                inner.wait_for_action(|action: &ActionResponse| match action {
+                let _ = inner.wait_for_action(|action: &ActionResponse| match action {
                     ActionResponse::Custom(action) => invocation_closure(action),
                     ActionResponse::Closed(_reason) => invocation_closure("__closed"), // FIXME: remove backward compatibility with 5.0
                 });
@@ -240,7 +240,7 @@ impl NotificationHandle {
         match self.inner {
             #[cfg(feature = "dbus")]
             NotificationHandleInner::Dbus(inner) => {
-                inner.wait_for_action(|action: &ActionResponse| {
+                let _ = inner.wait_for_action(|action: &ActionResponse| {
                     if let ActionResponse::Closed(reason) = action {
                         handler.call(*reason);
                     }
@@ -550,11 +550,12 @@ pub struct ServerInformation {
 /// (xdg only)
 #[cfg(all(feature = "zbus", not(feature = "dbus")))]
 // #[deprecated(note="please use [`NotificationHandle::wait_for_action`]")]
-pub fn handle_action<F>(id: u32, func: F)
+pub fn handle_action<F>(id: u32, func: F) -> Result<()>
 where
     F: FnOnce(&ActionResponse),
 {
     block_on(zbus_rs::handle_action(id, func));
+    Ok(())
 }
 
 /// Listens for the `ActionInvoked(UInt32, String)` Signal.
@@ -563,11 +564,11 @@ where
 /// (xdg only)
 #[cfg(all(feature = "dbus", not(feature = "zbus")))]
 // #[deprecated(note="please use `NotificationHandle::wait_for_action`")]
-pub fn handle_action<F>(id: u32, func: F)
+pub fn handle_action<F>(id: u32, func: F) -> Result<()>
 where
     F: FnOnce(&ActionResponse),
 {
-    dbus_rs::handle_action(id, func);
+    dbus_rs::handle_action(id, func)
 }
 
 /// Listens for the `ActionInvoked(UInt32, String)` Signal.
@@ -576,14 +577,15 @@ where
 /// both dbus-rs and zbus, switch via `$ZBUS_NOTIFICATION`
 #[cfg(all(feature = "dbus", feature = "zbus"))]
 // #[deprecated(note="please use `NotificationHandle::wait_for_action`")]
-pub fn handle_action<F>(id: u32, func: F)
+pub fn handle_action<F>(id: u32, func: F) -> Result<()>
 where
     F: FnOnce(&ActionResponse),
 {
     if std::env::var(DBUS_SWITCH_VAR).is_ok() {
-        dbus_rs::handle_action(id, func);
+        dbus_rs::handle_action(id, func)
     } else {
         block_on(zbus_rs::handle_action(id, func));
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

`handle_action`, `wait_for_action`, and `on_close` in the dbus backend call `.unwrap()` on D-Bus connection and match-rule operations. When the session bus or notification daemon disconnects (e.g. during logout, session restart, or desktop environment crash), these unwraps cause the entire process to panic with errors like:

```
panic: called `Result::unwrap()` on an `Err` value: Error { kind:
Dbus(D-Bus error: Message recipient disconnected from message bus
without replying (org.freedesktop.DBus.Error.NoReply)) }
```

This is particularly common in long-running applications that spawn threads to listen for notification actions — when the desktop session ends, the D-Bus session bus goes away and the listener thread panics, crashing the entire process.

## Changes

- `dbus_rs::handle_action` → returns `Result<()>` instead of panicking
- `dbus_rs::wait_for_action_signal` → returns `Result<()>`, uses `?` instead of `.unwrap()`
- `DbusNotificationHandle::wait_for_action` and `on_close` → return `Result<()>`
- Public `NotificationHandle::wait_for_action` and `on_close` signatures are **unchanged** (errors are silently discarded, matching the existing pattern used by `close()`)
- Public `handle_action` function now returns `Result<()>`, allowing callers to handle D-Bus errors gracefully

## Related

This addresses the class of D-Bus panics originally reported in #54, where D-Bus `NoReply`/`Disconnected` errors cause crashes in applications using `handle_action`.

## Testing

Verified compilation with `--features d`, `--features z`, and `--features d,z` on Linux (Rust 1.94).