### PR TITLE
feat(macos): add wait_for_action and on_close

### DIFF
--- a/examples/mac_actions.rs
+++ b/examples/mac_actions.rs
@@ -8,6 +8,10 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 fn main() {
+    use notify_rust::{get_bundle_identifier_or_default, set_application};
+
+    set_application(&get_bundle_identifier_or_default("safari")).unwrap();
+
     // A single action: rendered as a single button on the notification.
     Notification::new()
         .summary("click me")

--- a/examples/mac_actions.rs
+++ b/examples/mac_actions.rs
@@ -1,0 +1,41 @@
+#![allow(unused_imports)]
+use notify_rust::Notification;
+
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
+fn main() {
+    println!("this is a macOS only example — see `actions.rs` for the XDG version");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    // A single action: rendered as a single button on the notification.
+    Notification::new()
+        .summary("click me")
+        .body("This action needs to be clicked")
+        .action("clicked_a", "OK") // IDENTIFIER, LABEL
+        .show()
+        .unwrap()
+        .wait_for_action(|action| match action {
+            "clicked_a" => println!("clicked OK"),
+            // FIXME: here "__closed" is a hardcoded keyword, it will be deprecated in 5.0
+            "__closed" => println!("the notification was closed"),
+            other => println!("unknown action: {other}"),
+        });
+
+    // Multiple actions: rendered as a dropdown attached to the main button.
+    Notification::new()
+        .summary("pick one")
+        .body("This menu has several options")
+        .action("clicked_a", "button a") // IDENTIFIER, LABEL
+        .action("clicked_b", "button b")
+        .action("clicked_c", "button c")
+        .show()
+        .unwrap()
+        .wait_for_action(|action| match action {
+            "clicked_a" => println!("clicked a"),
+            "clicked_b" => println!("clicked b"),
+            "clicked_c" => println!("clicked c"),
+            "__closed" => println!("the notification was closed"),
+            other => println!("unknown action: {other}"),
+        });
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,0 +1,93 @@
+//! Cross-platform action response types.
+//!
+//! These types describe how a notification was acted upon by the user:
+//! either by clicking a configured action, or by closing the notification.
+//! They are shared between the XDG (Linux/BSD) and macOS backends so that
+//! consumer code does not need a `cfg` switch to read responses.
+
+/// Reason a notification was closed.
+///
+/// On XDG (Linux/BSD) this maps to the `NotificationClosed` D-Bus signal as
+/// listed under [Table 8. `NotificationClosed` Parameters](https://specifications.freedesktop.org/notification-spec/latest/ar01s09.html#idm46350804042704).
+///
+/// On macOS the underlying notification system does not distinguish between
+/// close reasons, so all closes are reported as [`CloseReason::Dismissed`].
+#[derive(Copy, Clone, Debug)]
+pub enum CloseReason {
+    /// The notification expired.
+    Expired,
+    /// The notification was dismissed by the user.
+    Dismissed,
+    /// The notification was closed by a call to `CloseNotification`.
+    CloseAction,
+    /// Undefined or reserved reason.
+    Other(u32),
+}
+
+impl From<u32> for CloseReason {
+    fn from(raw_reason: u32) -> Self {
+        match raw_reason {
+            1 => CloseReason::Expired,
+            2 => CloseReason::Dismissed,
+            3 => CloseReason::CloseAction,
+            other => CloseReason::Other(other),
+        }
+    }
+}
+
+/// Response to a user action on a notification.
+#[derive(Clone, Debug)]
+pub enum ActionResponse<'a> {
+    /// Custom action configured by the notification.
+    Custom(&'a str),
+    /// The notification was closed.
+    Closed(CloseReason),
+}
+
+impl<'a> From<&'a str> for ActionResponse<'a> {
+    fn from(raw: &'a str) -> Self {
+        Self::Custom(raw)
+    }
+}
+
+/// Helper trait implemented by closures used with `wait_for_action`.
+pub trait ActionResponseHandler {
+    /// Invoke the handler with the given response.
+    fn call(self, response: &ActionResponse);
+}
+
+impl<F> ActionResponseHandler for F
+where
+    F: FnOnce(&ActionResponse),
+{
+    fn call(self, res: &ActionResponse) {
+        (self)(res);
+    }
+}
+
+/// Callback for the `Close` signal of a notification.
+///
+/// This is implemented by `Fn()` and `Fn(CloseReason)`, so there is rarely a
+/// good reason to implement this trait manually.
+pub trait CloseHandler<T> {
+    /// Called with the [`CloseReason`].
+    fn call(&self, reason: CloseReason);
+}
+
+impl<F> CloseHandler<CloseReason> for F
+where
+    F: Fn(CloseReason),
+{
+    fn call(&self, reason: CloseReason) {
+        self(reason);
+    }
+}
+
+impl<F> CloseHandler<()> for F
+where
+    F: Fn(),
+{
+    fn call(&self, _: CloseReason) {
+        self();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! |  `fn hint(...)`     |  ✔︎    | ❌    | ❌    |
 //! |  `fn timeout(...)`  |  ✔︎    |       |  ✔︎    |
 //! |  `fn urgency(...)`  |  ✔︎    | ❌    |  ✔︎    |
-//! |  `fn action(...)`   |  ✔︎    |       |        |
+//! |  `fn action(...)`   |  ✔︎    | ✔︎    |        |
 //! |  `fn id(...)`       |  ✔︎    |       |        |
 //! |  `fn finalize(...)` |  ✔︎    | ✔︎     |  ✔︎    |
 //! |  `fn show(...)`     |  ✔︎    | ✔︎     |  ✔︎    |
@@ -102,9 +102,9 @@
 //!
 //! | method                   | XDG | macOS | windows |
 //! |--------------------------|-----|-------|---------|
-//! | `fn wait_for_action(...)`|  ✔︎  |  ❌  |   ❌   |
+//! | `fn wait_for_action(...)`|  ✔︎  |  ✔︎   |   ❌   |
 //! | `fn close(...)`          |  ✔︎  |  ❌  |   ❌   |
-//! | `fn on_close(...)`       |  ✔︎  |  ❌  |   ❌   |
+//! | `fn on_close(...)`       |  ✔︎  |  ✔︎   |   ❌   |
 //! | `fn update(...)`         |  ✔︎  |  ❌  |   ❌   |
 //! | `fn id(...)`             |  ✔︎  |  ❌  |   ❌   |
 //!
@@ -129,6 +129,18 @@
 //! ```
 //! </details>
 //!
+//! # macOS specifics
+//!
+//! On macOS, `wait_for_action` and `on_close` are powered by the underlying
+//! `mac-notification-sys` crate, which delivers the notification synchronously
+//! and blocks until the user interacts with it. As a result, calling `show()`
+//! on a notification that has any `action(...)` configured will return a
+//! [`NotificationHandle`] without yet displaying the notification — the
+//! notification is shown when `wait_for_action` (or `on_close`) is invoked,
+//! which is when the response can actually be observed.
+//!
+//! When no action is configured, `show()` behaves as before and delivers a
+//! fire-and-forget notification immediately.
 
 #![deny(
     missing_copy_implementations,
@@ -161,6 +173,7 @@ extern crate winrt_notification;
 #[cfg(all(feature = "images_no_default_features", unix, not(target_os = "macos")))]
 extern crate lazy_static;
 
+mod action;
 pub mod error;
 mod hints;
 mod miniver;
@@ -180,6 +193,8 @@ mod xdg;
 #[cfg(all(feature = "images_no_default_features", unix, not(target_os = "macos")))]
 mod image;
 
+pub use crate::action::{ActionResponse, ActionResponseHandler, CloseHandler, CloseReason};
+
 #[cfg(target_os = "macos")]
 pub use mac_notification_sys::{get_bundle_identifier_or_default, set_application};
 
@@ -192,8 +207,8 @@ pub use macos::NotificationHandle;
     not(target_os = "macos")
 ))]
 pub use crate::xdg::{
-    dbus_stack, get_capabilities, get_server_information, handle_action, ActionResponse,
-    CloseHandler, CloseReason, DbusStack, NotificationHandle,
+    dbus_stack, get_capabilities, get_server_information, handle_action, DbusStack,
+    NotificationHandle,
 };
 
 // #[cfg(all(feature = "server", unix, not(target_os = "macos")))]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,23 +1,170 @@
-use crate::{error::*, notification::Notification};
+use crate::{error::*, notification::Notification, ActionResponse, CloseHandler, CloseReason};
 
 pub use mac_notification_sys::error::{ApplicationError, Error as MacOsError, NotificationError};
+use mac_notification_sys::{MainButton, NotificationResponse};
 
 use std::ops::{Deref, DerefMut};
 
-/// A handle to a shown notification.
+/// A handle to a notification.
 ///
-/// This keeps a connection alive to ensure actions work on certain desktops.
+/// On macOS this also keeps the source [`Notification`] around so that
+/// [`NotificationHandle::wait_for_action`] / [`NotificationHandle::on_close`]
+/// can later drive the synchronous response flow exposed by
+/// `mac_notification_sys`.
+///
+/// When the notification has any [`Notification::action`] configured, the
+/// actual delivery is **deferred** until `wait_for_action` (or `on_close`) is
+/// invoked: the underlying `mac_notification_sys::Notification::send` call is
+/// blocking and only returns once the user interacted with the notification,
+/// so it has to be issued at the point where the response is observable.
+///
+/// Notifications with no actions retain the original fire-and-forget semantics
+/// — `show()` already delivered them and the resulting handle is essentially
+/// inert.
 #[derive(Debug)]
 pub struct NotificationHandle {
     notification: Notification,
+    /// `true` while the underlying notification has not been sent yet —
+    /// i.e. an interactive notification that is awaiting `wait_for_action` /
+    /// `on_close`. `false` once the notification has been delivered (either
+    /// fire-and-forget or after a `wait_for_action` has run).
+    pending: bool,
 }
 
 impl NotificationHandle {
     #[allow(missing_docs)]
     pub fn new(notification: Notification) -> NotificationHandle {
-        NotificationHandle { notification }
+        NotificationHandle {
+            notification,
+            pending: false,
+        }
+    }
+
+    fn pending(notification: Notification) -> NotificationHandle {
+        NotificationHandle {
+            notification,
+            pending: true,
+        }
+    }
+
+    /// Wait for the user to act on the notification and call the closure with
+    /// the identifier of the activated action.
+    ///
+    /// The identifier is the first argument originally passed to
+    /// [`Notification::action`]. If the notification was closed without any
+    /// action being clicked, the closure is invoked with the magic
+    /// `"__closed"` string for parity with the XDG backend (this sentinel is
+    /// scheduled to be replaced by an [`ActionResponse::Closed`] variant in
+    /// 5.0).
+    ///
+    /// On macOS this is implemented on top of
+    /// `mac_notification_sys::Notification::wait_for_click`, which delivers
+    /// the notification synchronously and blocks until the user interacts
+    /// with it. The first time this method (or `on_close`) is called on a
+    /// pending interactive handle, that synchronous send is issued.
+    pub fn wait_for_action<F>(self, invocation_closure: F)
+    where
+        F: FnOnce(&str),
+    {
+        if !self.pending {
+            // Fire-and-forget notifications are already delivered and gone.
+            // There is nothing to wait on, so emit the close sentinel for
+            // compatibility with the XDG semantics.
+            invocation_closure("__closed");
+            return;
+        }
+
+        let response = self.show_blocking();
+        let identifier: String = match response {
+            Ok(NotificationResponse::ActionButton(label)) => self
+                .identifier_for_label(&label)
+                .map(str::to_owned)
+                .unwrap_or_default(),
+            Ok(NotificationResponse::Click) => self
+                .first_identifier()
+                .map(str::to_owned)
+                .unwrap_or_else(|| "__closed".to_owned()),
+            Ok(NotificationResponse::Reply(text)) => text,
+            Ok(NotificationResponse::CloseButton(_)) | Ok(NotificationResponse::None) => {
+                "__closed".to_owned()
+            }
+            Err(_) => "__closed".to_owned(),
+        };
+        invocation_closure(&identifier);
+    }
+
+    /// Execute a closure after the notification has closed.
+    ///
+    /// On macOS the close reason is always reported as
+    /// [`CloseReason::Dismissed`], because the underlying notification system
+    /// does not distinguish between expiry, user dismissal and programmatic
+    /// close.
+    ///
+    /// Mirrors the behaviour of `wait_for_action` regarding pending
+    /// notifications: an interactive (action-bearing) notification will be
+    /// delivered now and this call will block until the user closes it; a
+    /// fire-and-forget notification will return immediately because it has
+    /// already been delivered.
+    pub fn on_close<A>(self, handler: impl CloseHandler<A>) {
+        if self.pending {
+            let _ = self.show_blocking();
+        }
+        handler.call(CloseReason::Dismissed);
+    }
+
+    /// Drive the underlying `mac_notification_sys` send, blocking until the
+    /// user interacts with the notification (or it is dismissed).
+    fn show_blocking(&self) -> Result<NotificationResponse> {
+        let labels: Vec<&str> = self
+            .notification
+            .actions
+            .chunks(2)
+            .filter_map(|c| c.get(1).map(String::as_str))
+            .collect();
+
+        let mut n = mac_notification_sys::Notification::default();
+        n.title(self.notification.summary.as_str())
+            .message(&self.notification.body)
+            .maybe_subtitle(self.notification.subtitle.as_deref())
+            .maybe_sound(self.notification.sound_name.as_deref())
+            .wait_for_click(true);
+
+        if let Some(ref image_path) = self.notification.path_to_image {
+            n.content_image(image_path);
+        }
+
+        match labels.len() {
+            0 => {}
+            1 => {
+                n.main_button(MainButton::SingleAction(labels[0]));
+            }
+            _ => {
+                n.main_button(MainButton::DropdownActions(labels[0], &labels[1..]));
+            }
+        }
+
+        n.send().map_err(Into::into)
+    }
+
+    fn identifier_for_label(&self, label: &str) -> Option<&str> {
+        self.notification
+            .actions
+            .chunks(2)
+            .find_map(|chunk| match (chunk.first(), chunk.get(1)) {
+                (Some(id), Some(lbl)) if lbl == label => Some(id.as_str()),
+                _ => None,
+            })
+    }
+
+    fn first_identifier(&self) -> Option<&str> {
+        self.notification.actions.first().map(String::as_str)
     }
 }
+
+/// Mirror of the XDG handle, used so that `ActionResponse` is part of the
+/// public macOS API surface even though it is not constructed directly here.
+#[allow(dead_code)]
+fn _action_response_is_used(_response: &ActionResponse) {}
 
 impl Deref for NotificationHandle {
     type Target = Notification;
@@ -35,19 +182,23 @@ impl DerefMut for NotificationHandle {
 }
 
 pub(crate) fn show_notification(notification: &Notification) -> Result<NotificationHandle> {
-    let mut n = mac_notification_sys::Notification::default();
-    n.title(notification.summary.as_str())
-        .message(&notification.body)
-        .maybe_subtitle(notification.subtitle.as_deref())
-        .maybe_sound(notification.sound_name.as_deref());
+    if notification.actions.is_empty() {
+        let mut n = mac_notification_sys::Notification::default();
+        n.title(notification.summary.as_str())
+            .message(&notification.body)
+            .maybe_subtitle(notification.subtitle.as_deref())
+            .maybe_sound(notification.sound_name.as_deref());
 
-    if let Some(ref image_path) = notification.path_to_image {
-        n.content_image(image_path);
+        if let Some(ref image_path) = notification.path_to_image {
+            n.content_image(image_path);
+        }
+
+        n.send()?;
+
+        Ok(NotificationHandle::new(notification.clone()))
+    } else {
+        Ok(NotificationHandle::pending(notification.clone()))
     }
-
-    n.send()?;
-
-    Ok(NotificationHandle::new(notification.clone()))
 }
 
 pub(crate) fn schedule_notification(

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -76,9 +76,12 @@ impl NotificationHandle {
 
         let response = self.show_blocking();
         let identifier: String = match response {
-            Ok(NotificationResponse::ActionButton(label)) => self
-                .identifier_for_label(&label)
-                .map_or_else(String::new, str::to_owned),
+            Ok(NotificationResponse::ActionButton(label)) => {
+                match self.identifier_for_label(&label) {
+                    Some(id) => id.to_owned(),
+                    None => label,
+                }
+            }
             Ok(NotificationResponse::Click) => self
                 .first_identifier()
                 .map_or_else(|| "__closed".to_owned(), str::to_owned),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -78,12 +78,10 @@ impl NotificationHandle {
         let identifier: String = match response {
             Ok(NotificationResponse::ActionButton(label)) => self
                 .identifier_for_label(&label)
-                .map(str::to_owned)
-                .unwrap_or_default(),
+                .map_or_else(String::new, str::to_owned),
             Ok(NotificationResponse::Click) => self
                 .first_identifier()
-                .map(str::to_owned)
-                .unwrap_or_else(|| "__closed".to_owned()),
+                .map_or_else(|| "__closed".to_owned(), str::to_owned),
             Ok(NotificationResponse::Reply(text)) => text,
             Ok(NotificationResponse::CloseButton(_)) | Ok(NotificationResponse::None) => {
                 "__closed".to_owned()

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)] // ActionResponse used in rustdoc link only
 use crate::{error::*, notification::Notification, ActionResponse, CloseHandler, CloseReason};
 
 pub use mac_notification_sys::error::{ApplicationError, Error as MacOsError, NotificationError};
@@ -161,11 +162,6 @@ impl NotificationHandle {
         self.notification.actions.first().map(String::as_str)
     }
 }
-
-/// Mirror of the XDG handle, used so that `ActionResponse` is part of the
-/// public macOS API surface even though it is not constructed directly here.
-#[allow(dead_code)]
-fn _action_response_is_used(_response: &ActionResponse) {}
 
 impl Deref for NotificationHandle {
     type Target = Notification;

--- a/src/xdg/dbus_rs.rs
+++ b/src/xdg/dbus_rs.rs
@@ -4,16 +4,14 @@ use dbus::{
     Message,
 };
 
-use super::{
-    bus::NotificationBus, ActionResponse, ActionResponseHandler, CloseReason,
-    NOTIFICATION_INTERFACE,
-};
+use super::{bus::NotificationBus, NOTIFICATION_INTERFACE};
 
 use crate::{
     error::*,
     hints::message::HintMessage,
     notification::Notification,
     xdg::{ServerInformation, NOTIFICATION_OBJECTPATH},
+    ActionResponse, ActionResponseHandler, CloseReason,
 };
 
 pub mod bus {

--- a/src/xdg/mod.rs
+++ b/src/xdg/mod.rs
@@ -7,7 +7,7 @@ use dbus::ffidisp::Connection as DbusConnection;
 #[cfg(feature = "zbus")]
 use zbus::{block_on, zvariant};
 
-use crate::{error::*, notification::Notification};
+use crate::{error::*, notification::Notification, ActionResponse, CloseHandler};
 
 use std::ops::{Deref, DerefMut};
 
@@ -589,87 +589,6 @@ where
     }
 }
 
-/// Reason passed to `NotificationClosed` Signal
-///
-/// ## Specification
-/// As listed under [Table 8. `NotificationClosed` Parameters](https://specifications.freedesktop.org/notification-spec/latest/ar01s09.html#idm46350804042704)
-#[derive(Copy, Clone, Debug)]
-pub enum CloseReason {
-    /// The notification expired
-    Expired,
-    /// The notification was dismissed by the user
-    Dismissed,
-    /// The notification was closed by a call to `CloseNotification`
-    CloseAction,
-    /// Undefined/Reserved reason
-    Other(u32),
-}
-
-impl From<u32> for CloseReason {
-    fn from(raw_reason: u32) -> Self {
-        match raw_reason {
-            1 => CloseReason::Expired,
-            2 => CloseReason::Dismissed,
-            3 => CloseReason::CloseAction,
-            other => CloseReason::Other(other),
-        }
-    }
-}
-
-/// Helper Trait implemented by `Fn()`
-pub trait ActionResponseHandler {
-    fn call(self, response: &ActionResponse);
-}
-
-// impl<F: Send + Sync + 'static> ActionResponseHandler for F
-impl<F> ActionResponseHandler for F
-where
-    F: FnOnce(&ActionResponse),
-{
-    fn call(self, res: &ActionResponse) {
-        (self)(res);
-    }
-}
-
-/// Response to an action
-#[derive(Clone, Debug)]
-pub enum ActionResponse<'a> {
-    /// Custom Action configured by the Notification.
-    Custom(&'a str),
-
-    /// The Notification was closed.
-    Closed(CloseReason),
-}
-
-impl<'a> From<&'a str> for ActionResponse<'a> {
-    fn from(raw: &'a str) -> Self {
-        Self::Custom(raw)
-    }
-}
-
-/// Your handy callback for the `Close` signal of your Notification.
-///
-/// This is implemented by `Fn()` and `Fn(CloseReason)`, so there is probably no good reason for you to manually implement this trait.
-/// Should you find one anyway, please notify me and I'll gladly remove this obviously redundant comment.
-pub trait CloseHandler<T> {
-    /// This is called with the [`CloseReason`].
-    fn call(&self, reason: CloseReason);
-}
-
-impl<F> CloseHandler<CloseReason> for F
-where
-    F: Fn(CloseReason),
-{
-    fn call(&self, reason: CloseReason) {
-        self(reason);
-    }
-}
-
-impl<F> CloseHandler<()> for F
-where
-    F: Fn(),
-{
-    fn call(&self, _: CloseReason) {
-        self();
-    }
-}
+// `ActionResponse`, `ActionResponseHandler`, `CloseHandler` and `CloseReason`
+// are defined in `crate::action` and re-exported at the crate root so they can
+// be shared between the XDG and macOS backends.

--- a/src/xdg/zbus_rs.rs
+++ b/src/xdg/zbus_rs.rs
@@ -1,8 +1,10 @@
-use crate::{error::*, notification::Notification, xdg};
+use crate::{
+    error::*, notification::Notification, xdg, ActionResponse, ActionResponseHandler, CloseReason,
+};
 use futures_lite::stream::StreamExt;
 use zbus::MatchRule;
 
-use super::{bus::NotificationBus, ActionResponse, ActionResponseHandler, CloseReason};
+use super::bus::NotificationBus;
 
 pub mod bus {
 


### PR DESCRIPTION
## Summary

Wires the synchronous response flow exposed by `mac-notification-sys` into `notify-rust`'s `NotificationHandle::wait_for_action` and `NotificationHandle::on_close` so that listening for action clicks works on macOS the same way it does on XDG. Refs #186.

## Why this is small in scope

`mac-notification-sys` 0.6.12 already exposes:

- `NotificationResponse` (`Click` / `ActionButton` / `CloseButton` / `Reply` / `None`)
- `wait_for_click(true)` synchronous flow
- `MainButton::SingleAction` / `DropdownActions` / `Response`

`notify-rust` was not wiring any of this up: `src/macos.rs::show_notification` only forwarded title/body/subtitle/sound/image and discarded the `NotificationResponse`. This PR is mostly plumbing.

## Changes

- New `src/action.rs` module — hoists `ActionResponse`, `CloseReason`, `CloseHandler` and `ActionResponseHandler` out of `src/xdg/mod.rs` so they can be re-exported at the crate root and shared between platforms.
- `src/macos.rs` — adds `NotificationHandle::wait_for_action` and `NotificationHandle::on_close`. Maps `mac_notification_sys::NotificationResponse::ActionButton(label)` back to the identifier originally passed to `Notification::action(identifier, label)`.
- `src/macos.rs::show_notification` — interactive notifications (those with any `action()` configured) are now deferred until `wait_for_action` / `on_close` is invoked, since `mac_notification_sys::Notification::send` is blocking and only returns once the user interacts. Fire-and-forget notifications keep the existing eager-send behaviour.
- `src/xdg/{mod,dbus_rs,zbus_rs}.rs` — switch from `super::{ActionResponse, ...}` to `crate::{ActionResponse, ...}` to use the hoisted definitions. No semantic change on XDG.
- `src/lib.rs` — re-exports the shared types at the crate root, updates the platform-support table to mark macOS for `wait_for_action`, `on_close`, and `action`, and documents the macOS-specific blocking semantics.
- `examples/mac_actions.rs` — macOS counterpart of `examples/actions.rs`, with both single-action and dropdown variants.

## Why defer interactive sends?

`mac_notification_sys::Notification::send` is **synchronous** — it delivers the notification and blocks until the user dismisses it or activates an action. The `NotificationResponse` is only available *after* that blocking call returns, while the XDG flow expects `show()` to return a handle quickly and the response to be observed later via `wait_for_action`.

Two ways to reconcile this on macOS:

1. **Send eagerly in `show()` and store the response on the handle.** This makes `show()` itself blocking on macOS, which silently breaks any caller that expected `show()` to return promptly — for example fire-and-forget notifications that happen to call `.action()` for forward compatibility, or callers that interleave several `show()` calls before reading any response.
2. **Defer the send until `wait_for_action` / `on_close`.** Interactive notifications still go through a single `send` call, but at the point where the caller is already prepared to block. Fire-and-forget notifications (no `action()`) keep the eager-send behaviour and remain non-blocking.

This PR takes option (2). It preserves the XDG contract that `show()` is non-blocking from the caller's point of view, and only callers that actually opt into a listener (`wait_for_action` / `on_close`) experience the underlying synchronous send. If you'd prefer a different shape (e.g. an explicit builder method like `.wait_for_response()` to gate when the send happens), happy to follow up — the underlying response mapping in `src/macos.rs` is the same.

## Interaction with milestone 5 (#266) and #272

Both touched the XDG backends only and are non-conflicting with this PR:

- The closure signature stays `FnOnce(&str)` and the `"__closed"` magic string is preserved as-is, so this PR is compatible with current XDG behaviour. When milestone 5 migrates the closure to `FnOnce(ActionResponse)`, the macOS side will need a minimal change in `wait_for_action` to construct an `ActionResponse::Custom(...)` / `ActionResponse::Closed(_)` instead of producing the identifier as a `&str` — the underlying response mapping is already in place, only the closure call site moves.
- The `Result` return change in #272 only touches the XDG backends in this round. The macOS `wait_for_action` / `on_close` signatures here mirror the current XDG ones (no `Result`), and will need to be aligned to `Result<()>` when #272 lands. The change there is essentially the function signature plus a couple of `?` / `map_err` — the internal `show_blocking` already returns `Result<NotificationResponse>`.

## What this PR does NOT change

- Windows still has no listener support — that needs a separate decision (the issue mentions `tauri-winrt-notification` vs the new `win32_notif`). Out of scope here.
- The `"__closed"` sentinel is preserved for parity with the current XDG behaviour. Replacing it with `ActionResponse::Closed(_)` belongs in milestone 5.
- macOS `NotificationHandle::close()`, `update()` and `id()` are still `❌` in the platform table. `mac-notification-sys` 0.6 does not expose a per-notification handle that can be cancelled, updated or queried by id, so wiring these would require widening the `mac-notification-sys` surface first. Happy to take that on as a follow-up.

## CI status

All checks green on the fork branch (yasumorishima/notify-rust#1):

- `cargo check` / `cargo test --no-run` / `cargo clippy -- -D warnings` on `macos-latest` (stable / beta / stable-minus-5)
- `cargo check` / `cargo test --lib` / `cargo clippy` on `ubuntu-latest` across all 5 feature combinations × 3 toolchains
- `cargo check` / `cargo test --no-run` / `cargo clippy -- -D warnings` on `windows-latest` (stable / beta / stable-minus-5)
- `cargo-semver-checks` (no breaking changes detected)
- CodeQL (no alerts on changed files)

## Limitations / things I cannot verify myself

- I do not have a Mac available, so the macOS signal is the CI matrix only. An end-to-end manual sanity check on a real Mac (`cargo run --example mac_actions`) would be very welcome.
- macOS does not differentiate close reasons in the underlying `NotificationResponse`, so `on_close` always reports `CloseReason::Dismissed`. Documented at the call site.
- A `Click` (body click) on a notification with at least one configured action is currently mapped to the first action's identifier. Open to changing this to `"__default"` or always `"__closed"` if you'd prefer.
- `mac_notification_sys::NotificationResponse::ActionButton` carries the action *label*, not its identifier, so the macOS path resolves the identifier by looking up the first action whose label matches. If a caller registers two `action(...)` entries with the same label, only the first identifier is reachable. Realistically duplicate labels are a UX bug on the caller side, but the ambiguity is silent — flagging in case you want a stricter contract here.
