### PR TITLE
fix: return Result from update() instead of panicking on D-Bus errors

### DIFF
--- a/src/xdg/dbus_rs.rs
+++ b/src/xdg/dbus_rs.rs
@@ -108,9 +108,9 @@ impl DbusNotificationHandle {
         })
     }
 
-    pub fn update(&mut self) {
-        self.id = send_notification_via_connection(&self.notification, self.id, &self.connection)
-            .unwrap();
+    pub fn update(&mut self) -> Result<()> {
+        self.id = send_notification_via_connection(&self.notification, self.id, &self.connection)?;
+        Ok(())
     }
 }
 

--- a/src/xdg/mod.rs
+++ b/src/xdg/mod.rs
@@ -271,13 +271,13 @@ impl NotificationHandle {
     /// notification.summary("Latest News (Correction)")
     ///             .body("Bayern Dortmund 3:3");
     ///
-    /// notification.update();
+    /// notification.update().unwrap();
     /// ```
     /// Watch out for different implementations of the
     /// notification server! On plasma5 for instance, you should also change the appname, so the old
     /// message is really replaced and not just amended. Xfce behaves well, all others have not
     /// been tested by the developer.
-    pub fn update(&mut self) {
+    pub fn update(&mut self) -> Result<()> {
         match self.inner {
             #[cfg(feature = "dbus")]
             NotificationHandleInner::Dbus(ref mut inner) => inner.update(),

--- a/src/xdg/zbus_rs.rs
+++ b/src/xdg/zbus_rs.rs
@@ -118,8 +118,8 @@ impl ZbusNotificationHandle {
         Ok(())
     }
 
-    pub fn update(&mut self) {
-        self.update_fallible().unwrap();
+    pub fn update(&mut self) -> Result<()> {
+        self.update_fallible()
     }
 }
 


### PR DESCRIPTION
Same pattern as dbd4fd6 (`handle_action` fix from #270). The `update()` method calls `send_notification_via_connection()` which can fail when the D-Bus session bus disconnects (e.g. screen lock, DE restart, logout).

Previously this panicked via `.unwrap()`; now it returns `Result<()>` so callers can handle the error gracefully.

Applies to both dbus and zbus backends.