### PR TITLE
Add macOS and Windows notification action listeners

### DIFF
--- a/examples/mac.rs
+++ b/examples/mac.rs
@@ -5,12 +5,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let bundle_id = get_bundle_identifier_or_default("zed");
     set_application(&bundle_id).unwrap();
 
-    Notification::new()
+    let handle = Notification::new()
         .summary("Safari Crashed")
         .body("Just kidding, this is just the notify_rust example.")
         .appname("Toastify")
         .icon("Toastify")
+        .action("open", "Open")
         .show()?;
+
+    handle.wait_for_action(|action| {
+        println!("action: {action}");
+    });
 
     Notification::new()
         .summary(".image_path()")

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -2,9 +2,14 @@ extern crate notify_rust;
 use notify_rust::Notification;
 
 fn main() {
-    Notification::new()
+    let handle = Notification::new()
         .summary("Notify Rust Windows")
         .body("yay, we have limited windows support\nWith multiple lines\nSound\nImages")
+        .action("open", "Open")
         .show()
         .unwrap();
+
+    handle.wait_for_action(|action| {
+        println!("action: {action}");
+    });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! |  `fn hint(...)`     |  ✔︎    | ❌    | ❌    |
 //! |  `fn timeout(...)`  |  ✔︎    |       |  ✔︎    |
 //! |  `fn urgency(...)`  |  ✔︎    | ❌    |  ✔︎    |
-//! |  `fn action(...)`   |  ✔︎    |       |        |
+//! |  `fn action(...)`   |  ✔︎    | ✔︎     |  ✔︎    |
 //! |  `fn id(...)`       |  ✔︎    |       |        |
 //! |  `fn finalize(...)` |  ✔︎    | ✔︎     |  ✔︎    |
 //! |  `fn show(...)`     |  ✔︎    | ✔︎     |  ✔︎    |
@@ -102,7 +102,7 @@
 //!
 //! | method                   | XDG | macOS | windows |
 //! |--------------------------|-----|-------|---------|
-//! | `fn wait_for_action(...)`|  ✔︎  |  ❌  |   ❌   |
+//! | `fn wait_for_action(...)`|  ✔︎  |  ✔︎  |   ✔︎   |
 //! | `fn close(...)`          |  ✔︎  |  ❌  |   ❌   |
 //! | `fn on_close(...)`       |  ✔︎  |  ❌  |   ❌   |
 //! | `fn update(...)`         |  ✔︎  |  ❌  |   ❌   |
@@ -185,6 +185,9 @@ pub use mac_notification_sys::{get_bundle_identifier_or_default, set_application
 
 #[cfg(target_os = "macos")]
 pub use macos::NotificationHandle;
+
+#[cfg(target_os = "windows")]
+pub use windows::NotificationHandle;
 
 #[cfg(all(
     any(feature = "dbus", feature = "zbus"),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,7 @@
-use crate::{error::*, notification::action_pairs, notification::Notification};
+use crate::{
+    error::*,
+    notification::{action_pairs, delivery_date_is_in_past, Notification},
+};
 
 use mac_notification_sys::{MainButton, NotificationResponse};
 
@@ -7,6 +10,7 @@ pub use mac_notification_sys::error::{ApplicationError, Error as MacOsError, Not
 use std::ops::{Deref, DerefMut};
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A handle to a shown notification.
 ///
@@ -84,6 +88,8 @@ pub(crate) fn schedule_notification(
     notification: &Notification,
     delivery_date: f64,
 ) -> Result<NotificationHandle> {
+    validate_delivery_date(delivery_date)?;
+
     let notification = notification.clone();
     let handle_notification = notification.clone();
     let (sender, receiver) = mpsc::channel();
@@ -133,6 +139,19 @@ fn send_waiting_notification(
     }
 
     n.send()
+}
+
+fn validate_delivery_date(delivery_date: f64) -> Result<()> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs_f64())
+        .unwrap_or(0.0);
+
+    if delivery_date_is_in_past(delivery_date, now) {
+        return Err(NotificationError::ScheduleInThePast.into());
+    }
+
+    Ok(())
 }
 
 fn response_to_action(response: &NotificationResponse, actions: &[String]) -> Option<String> {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,21 +1,50 @@
-use crate::{error::*, notification::Notification};
+use crate::{error::*, notification::action_pairs, notification::Notification};
+
+use mac_notification_sys::{MainButton, NotificationResponse};
 
 pub use mac_notification_sys::error::{ApplicationError, Error as MacOsError, NotificationError};
 
 use std::ops::{Deref, DerefMut};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
 
 /// A handle to a shown notification.
 ///
 /// This keeps a connection alive to ensure actions work on certain desktops.
-#[derive(Debug)]
 pub struct NotificationHandle {
     notification: Notification,
+    action_response: Receiver<Option<String>>,
+}
+
+impl std::fmt::Debug for NotificationHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NotificationHandle")
+            .field("notification", &self.notification)
+            .finish_non_exhaustive()
+    }
 }
 
 impl NotificationHandle {
     #[allow(missing_docs)]
-    pub fn new(notification: Notification) -> NotificationHandle {
-        NotificationHandle { notification }
+    pub fn new(notification: Notification, action_response: Receiver<Option<String>>) -> Self {
+        Self {
+            notification,
+            action_response,
+        }
+    }
+
+    /// Waits for the user to act on a notification and then calls
+    /// `invocation_closure` with the name of the corresponding action.
+    ///
+    /// Clicking the notification body returns `"default"`. Closing the notification returns
+    /// `"__closed"` for compatibility with the XDG backend.
+    pub fn wait_for_action<F>(self, invocation_closure: F)
+    where
+        F: FnOnce(&str),
+    {
+        if let Ok(Some(action)) = self.action_response.recv() {
+            invocation_closure(&action);
+        }
     }
 }
 
@@ -35,37 +64,87 @@ impl DerefMut for NotificationHandle {
 }
 
 pub(crate) fn show_notification(notification: &Notification) -> Result<NotificationHandle> {
-    let mut n = mac_notification_sys::Notification::default();
-    n.title(notification.summary.as_str())
-        .message(&notification.body)
-        .maybe_subtitle(notification.subtitle.as_deref())
-        .maybe_sound(notification.sound_name.as_deref());
+    let notification = notification.clone();
+    let handle_notification = notification.clone();
+    let (sender, receiver) = mpsc::channel();
 
-    if let Some(ref image_path) = notification.path_to_image {
-        n.content_image(image_path);
-    }
+    thread::spawn(move || {
+        let response = send_waiting_notification(&notification, None);
+        let _ = sender.send(
+            response
+                .ok()
+                .and_then(|response| response_to_action(&response, &notification.actions)),
+        );
+    });
 
-    n.send()?;
-
-    Ok(NotificationHandle::new(notification.clone()))
+    Ok(NotificationHandle::new(handle_notification, receiver))
 }
 
 pub(crate) fn schedule_notification(
     notification: &Notification,
     delivery_date: f64,
 ) -> Result<NotificationHandle> {
+    let notification = notification.clone();
+    let handle_notification = notification.clone();
+    let (sender, receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        let response = send_waiting_notification(&notification, Some(delivery_date));
+        let _ = sender.send(
+            response
+                .ok()
+                .and_then(|response| response_to_action(&response, &notification.actions)),
+        );
+    });
+
+    Ok(NotificationHandle::new(handle_notification, receiver))
+}
+
+fn send_waiting_notification(
+    notification: &Notification,
+    delivery_date: Option<f64>,
+) -> std::result::Result<NotificationResponse, MacOsError> {
     let mut n = mac_notification_sys::Notification::default();
     n.title(notification.summary.as_str())
         .message(&notification.body)
         .maybe_subtitle(notification.subtitle.as_deref())
         .maybe_sound(notification.sound_name.as_deref())
-        .delivery_date(delivery_date);
+        .wait_for_click(true);
+
+    if let Some(delivery_date) = delivery_date {
+        n.delivery_date(delivery_date);
+    }
+
+    let action_labels = action_pairs(&notification.actions)
+        .map(|(_identifier, label)| label)
+        .collect::<Vec<_>>();
+    match action_labels.as_slice() {
+        [] => {}
+        [label] => {
+            n.main_button(MainButton::SingleAction(label));
+        }
+        labels => {
+            n.main_button(MainButton::DropdownActions("Actions", labels));
+        }
+    }
 
     if let Some(ref image_path) = notification.path_to_image {
         n.content_image(image_path);
     }
 
-    n.send()?;
+    n.send()
+}
 
-    Ok(NotificationHandle::new(notification.clone()))
+fn response_to_action(response: &NotificationResponse, actions: &[String]) -> Option<String> {
+    match response {
+        NotificationResponse::Click => Some("default".to_owned()),
+        NotificationResponse::ActionButton(label) => action_pairs(actions)
+            .find_map(|(identifier, action_label)| {
+                (action_label == label).then(|| identifier.to_owned())
+            })
+            .or_else(|| Some(label.clone())),
+        NotificationResponse::CloseButton(_) => Some("__closed".to_owned()),
+        NotificationResponse::Reply(reply) => Some(reply.clone()),
+        NotificationResponse::None => None,
+    }
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -8,9 +8,11 @@ use mac_notification_sys::{MainButton, NotificationResponse};
 pub use mac_notification_sys::error::{ApplicationError, Error as MacOsError, NotificationError};
 
 use std::ops::{Deref, DerefMut};
-use std::sync::mpsc::{self, Receiver};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const STARTUP_ERROR_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// A handle to a shown notification.
 ///
@@ -71,15 +73,22 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<Notificat
     let notification = notification.clone();
     let handle_notification = notification.clone();
     let (sender, receiver) = mpsc::channel();
+    let (startup_sender, startup_receiver) = mpsc::channel();
 
     thread::spawn(move || {
         let response = send_waiting_notification(&notification, None);
-        let _ = sender.send(
-            response
-                .ok()
-                .and_then(|response| response_to_action(&response, &notification.actions)),
-        );
+        match response {
+            Ok(response) => {
+                let _ = sender.send(response_to_action(&response, &notification.actions));
+            }
+            Err(error) => {
+                let _ = startup_sender.send(error);
+                let _ = sender.send(None);
+            }
+        }
     });
+
+    return_startup_error(startup_receiver)?;
 
     Ok(NotificationHandle::new(handle_notification, receiver))
 }
@@ -93,15 +102,22 @@ pub(crate) fn schedule_notification(
     let notification = notification.clone();
     let handle_notification = notification.clone();
     let (sender, receiver) = mpsc::channel();
+    let (startup_sender, startup_receiver) = mpsc::channel();
 
     thread::spawn(move || {
         let response = send_waiting_notification(&notification, Some(delivery_date));
-        let _ = sender.send(
-            response
-                .ok()
-                .and_then(|response| response_to_action(&response, &notification.actions)),
-        );
+        match response {
+            Ok(response) => {
+                let _ = sender.send(response_to_action(&response, &notification.actions));
+            }
+            Err(error) => {
+                let _ = startup_sender.send(error);
+                let _ = sender.send(None);
+            }
+        }
     });
+
+    return_startup_error(startup_receiver)?;
 
     Ok(NotificationHandle::new(handle_notification, receiver))
 }
@@ -152,6 +168,13 @@ fn validate_delivery_date(delivery_date: f64) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn return_startup_error(receiver: Receiver<MacOsError>) -> Result<()> {
+    match receiver.recv_timeout(STARTUP_ERROR_TIMEOUT) {
+        Ok(error) => Err(error.into()),
+        Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => Ok(()),
+    }
 }
 
 fn response_to_action(response: &NotificationResponse, actions: &[String]) -> Option<String> {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -516,6 +516,11 @@ pub(crate) fn action_pairs(actions: &[String]) -> impl Iterator<Item = (&str, &s
         .map(|chunk| (chunk[0].as_str(), chunk[1].as_str()))
 }
 
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn delivery_date_is_in_past(delivery_date: f64, now_unix_seconds: f64) -> bool {
+    delivery_date < now_unix_seconds
+}
+
 impl Default for Notification {
     #[cfg(all(unix, not(target_os = "macos")))]
     fn default() -> Notification {
@@ -571,7 +576,7 @@ impl Default for Notification {
 
 #[cfg(test)]
 mod tests {
-    use super::action_pairs;
+    use super::{action_pairs, delivery_date_is_in_past};
 
     #[test]
     fn action_pairs_ignores_incomplete_trailing_action() {
@@ -585,5 +590,12 @@ mod tests {
         let pairs = action_pairs(&actions).collect::<Vec<_>>();
 
         assert_eq!(pairs, vec![("default", "Open"), ("reply", "Reply")]);
+    }
+
+    #[test]
+    fn delivery_date_past_validation_matches_backend_boundary() {
+        assert!(delivery_date_is_in_past(9.0, 10.0));
+        assert!(!delivery_date_is_in_past(10.0, 10.0));
+        assert!(!delivery_date_is_in_past(11.0, 10.0));
     }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -479,19 +479,17 @@ impl Notification {
 
     /// Sends Notification to `NSUserNotificationCenter`.
     ///
-    /// Returns an `Ok` no matter what, since there is currently no way of telling the success of
-    /// the notification.
+    /// Returns a handle that can wait for notification clicks and action button responses.
     #[cfg(target_os = "macos")]
     pub fn show(&self) -> Result<macos::NotificationHandle> {
         macos::show_notification(self)
     }
 
-    /// Sends Notification to `NSUserNotificationCenter`.
+    /// Sends Notification as a Windows toast.
     ///
-    /// Returns an `Ok` no matter what, since there is currently no way of telling the success of
-    /// the notification.
+    /// Returns a handle that can wait for notification clicks and action button responses.
     #[cfg(target_os = "windows")]
-    pub fn show(&self) -> Result<()> {
+    pub fn show(&self) -> Result<windows::NotificationHandle> {
         windows::show_notification(self)
     }
 
@@ -509,6 +507,13 @@ impl Notification {
         );
         self.show()
     }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
+pub(crate) fn action_pairs(actions: &[String]) -> impl Iterator<Item = (&str, &str)> {
+    actions
+        .chunks_exact(2)
+        .map(|chunk| (chunk[0].as_str(), chunk[1].as_str()))
 }
 
 impl Default for Notification {
@@ -561,5 +566,24 @@ impl Default for Notification {
             app_id: None,
             urgency: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::action_pairs;
+
+    #[test]
+    fn action_pairs_ignores_incomplete_trailing_action() {
+        let actions = vec![
+            "default".to_owned(),
+            "Open".to_owned(),
+            "reply".to_owned(),
+            "Reply".to_owned(),
+            "dangling".to_owned(),
+        ];
+        let pairs = action_pairs(&actions).collect::<Vec<_>>();
+
+        assert_eq!(pairs, vec![("default", "Open"), ("reply", "Reply")]);
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,10 +1,64 @@
 use winrt_notification::Toast;
 
+use crate::notification::action_pairs;
 pub use crate::{error::*, notification::Notification, timeout::Timeout, urgency::Urgency};
 
+use std::ops::{Deref, DerefMut};
+use std::sync::mpsc::{self, Receiver};
 use std::{path::Path, str::FromStr};
 
-pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
+/// A handle to a shown Windows toast notification.
+pub struct NotificationHandle {
+    notification: Notification,
+    action_response: Receiver<String>,
+}
+
+impl std::fmt::Debug for NotificationHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NotificationHandle")
+            .field("notification", &self.notification)
+            .finish_non_exhaustive()
+    }
+}
+
+impl NotificationHandle {
+    pub(crate) fn new(notification: Notification, action_response: Receiver<String>) -> Self {
+        Self {
+            notification,
+            action_response,
+        }
+    }
+
+    /// Waits for the user to act on a notification and then calls
+    /// `invocation_closure` with the name of the corresponding action.
+    ///
+    /// Clicking the notification body returns `"default"`. Closing the notification returns
+    /// `"__closed"` for compatibility with the XDG backend.
+    pub fn wait_for_action<F>(self, invocation_closure: F)
+    where
+        F: FnOnce(&str),
+    {
+        if let Ok(action) = self.action_response.recv() {
+            invocation_closure(&action);
+        }
+    }
+}
+
+impl Deref for NotificationHandle {
+    type Target = Notification;
+
+    fn deref(&self) -> &Notification {
+        &self.notification
+    }
+}
+
+impl DerefMut for NotificationHandle {
+    fn deref_mut(&mut self) -> &mut Notification {
+        &mut self.notification
+    }
+}
+
+pub(crate) fn show_notification(notification: &Notification) -> Result<NotificationHandle> {
     let sound = match &notification.sound_name {
         Some(chosen_sound_name) => winrt_notification::Sound::from_str(chosen_sound_name).ok(),
         None => None,
@@ -32,12 +86,24 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
 
     let powershell_app_id = &Toast::POWERSHELL_APP_ID.to_string();
     let app_id = &notification.app_id.as_ref().unwrap_or(powershell_app_id);
+    let (sender, receiver) = mpsc::channel();
+    let activated_sender = sender.clone();
+    let dismissed_sender = sender;
+
     let mut toast = Toast::new(app_id)
         .title(&notification.summary)
         .text1(notification.subtitle.as_ref().map_or("", AsRef::as_ref)) // subtitle
         .text2(&notification.body)
         .sound(sound)
-        .duration(duration);
+        .duration(duration)
+        .on_activated(move |action| {
+            let _ = activated_sender.send(action.unwrap_or_else(|| "default".to_owned()));
+            Ok(())
+        })
+        .on_dismissed(move |_reason| {
+            let _ = dismissed_sender.send("__closed".to_owned());
+            Ok(())
+        });
 
     // Apply scenario only for critical urgency
     if let Some(scenario) = scenario {
@@ -46,8 +112,13 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
     if let Some(image_path) = &notification.path_to_image {
         toast = toast.image(Path::new(&image_path), "");
     }
+    for (identifier, label) in action_pairs(&notification.actions) {
+        toast = toast.add_button(label, identifier);
+    }
 
     toast
         .show()
-        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))
+        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))?;
+
+    Ok(NotificationHandle::new(notification.clone(), receiver))
 }


### PR DESCRIPTION
/claim #186

## Summary

- add `NotificationHandle::wait_for_action` support on macOS and Windows
- keep macOS `Notification::show()` / `schedule_*()` nonblocking by running the `mac-notification-sys` waiting call on a background thread
- wire `Notification::action(identifier, label)` into macOS notification buttons and Windows toast buttons
- return `"default"` for notification body clicks and `"__closed"` for dismissals to match the existing XDG callback convention
- preserve immediate macOS scheduling and startup errors before returning a listener handle
- update the platform support table and macOS/Windows examples

## Why this approach

This is deliberately scoped to the existing synchronous `wait_for_action` API. On macOS, the underlying `mac-notification-sys` response call blocks while waiting for a user action, so this PR moves that wait into a background thread and returns the handle immediately. That addresses the blocking concern from the earlier macOS-only attempt while also covering the Windows listener path requested in #186.

## Validation

- `cargo fmt -- --check`
- `cargo check --all-features`
- `cargo test --lib --all-features`
- `cargo doc --no-deps`
- `cargo clippy --lib -- -D warnings`
- `cargo check --target x86_64-pc-windows-gnu`
- `cargo check --target x86_64-pc-windows-gnu --example windows`
- `cargo clippy --target x86_64-pc-windows-gnu -- -D warnings`
- `cargo check --target x86_64-pc-windows-gnu --tests`
- `cargo check --no-default-features --features z`
- `cargo test --lib --no-default-features --features z`
- `cargo test --doc --no-default-features --features z`
- `cargo check --no-default-features --features z,images`
- `cargo test --lib --no-default-features --features z,images`
- `cargo test --doc --no-default-features --features z,images`

Notes: full Linux integration tests require a desktop notification service; upstream CI also leaves full `cargo test` commented out and runs lib/doc tests instead. The local container also lacks `libdbus-1-dev`, so the `d` feature matrix could not be reproduced here; upstream CI installs that package before running it.