### PR TITLE
Add notification action/close listeners for macOS and Windows (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* add `NotificationHandle` listener APIs for macOS responses and a Windows
+handle placeholder documenting current backend activation limits.
+
 ## [v4.17.0](https://github.com/hoodie/notify-rust/compare/v4.16.1...v4.17.0) (2026-05-05)
 
 ### Features

--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+Unreleased
+==========
+  * add macOS notification response listeners using a background thread and
+    one-shot channel
+  * return a Windows NotificationHandle and document the current toast
+    activation callback limitation
+
 v4.0.0-alpha
 ==================
   * dbus message types are now hidden
@@ -349,5 +356,4 @@ v0.0.3 / 2015-05-24
 
 v0.0.2 / 2015-05-22
 ===================
-
 

--- a/examples/listen.rs
+++ b/examples/listen.rs
@@ -1,0 +1,37 @@
+#![allow(unused_imports)]
+
+use notify_rust::Notification;
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn main() {
+    Notification::new()
+        .summary("click me")
+        .body("Waiting for your response.")
+        .action("default", "default")
+        .action("open", "Open")
+        .show()
+        .unwrap()
+        .wait_for_action(|action| println!("action: {action}"));
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    Notification::new()
+        .summary("click me")
+        .body("Waiting for your response.")
+        .action("default", "default")
+        .show()
+        .unwrap()
+        .wait_for_action(|action| println!("action: {action}"));
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    let _handle = Notification::new()
+        .summary("Notify Rust Windows")
+        .body("Windows toast activation is not exposed by the backend yet.")
+        .show()
+        .unwrap();
+
+    println!("Windows listener callbacks are not exposed by tauri-winrt-notification 0.7");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,16 @@
 //!
 //! | method                   | XDG | macOS | windows |
 //! |--------------------------|-----|-------|---------|
-//! | `fn wait_for_action(...)`|  ✔︎  |  ❌  |   ❌   |
+//! | `fn wait_for_action(...)`|  ✔︎  |  ✔︎  |   stub |
 //! | `fn close(...)`          |  ✔︎  |  ❌  |   ❌   |
-//! | `fn on_close(...)`       |  ✔︎  |  ❌  |   ❌   |
+//! | `fn on_close(...)`       |  ✔︎  |  ✔︎  |   stub |
+//! | `fn on_response(...)`    |     |  ✔︎  |   stub |
 //! | `fn update(...)`         |  ✔︎  |  ❌  |   ❌   |
 //! | `fn id(...)`             |  ✔︎  |  ❌  |   ❌   |
+//!
+//! On Windows these listener methods exist on `NotificationHandle` so
+//! cross-platform code can compile, but the `tauri-winrt-notification` backend
+//! does not currently expose toast activation or dismissal callbacks.
 //!
 //! ## Functions
 //!
@@ -184,7 +189,10 @@ mod image;
 pub use mac_notification_sys::{get_bundle_identifier_or_default, set_application};
 
 #[cfg(target_os = "macos")]
-pub use macos::NotificationHandle;
+pub use macos::{ActionResponse, CloseHandler, CloseReason, NotificationHandle};
+
+#[cfg(target_os = "windows")]
+pub use windows::{ActionResponse, CloseHandler, CloseReason, NotificationHandle};
 
 #[cfg(all(
     any(feature = "dbus", feature = "zbus"),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -2,20 +2,132 @@ use crate::{error::*, notification::Notification};
 
 pub use mac_notification_sys::error::{ApplicationError, Error as MacOsError, NotificationError};
 
-use std::ops::{Deref, DerefMut};
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+    sync::mpsc::{self, Receiver},
+    thread,
+};
+
+/// Reason why a notification closed.
+#[derive(Copy, Clone, Debug)]
+pub enum CloseReason {
+    /// The notification expired.
+    Expired,
+    /// The user dismissed the notification.
+    Dismissed,
+    /// The notification was closed because the user clicked an action.
+    CloseAction,
+    /// The platform did not expose a more specific reason.
+    Other(u32),
+}
+
+/// Response to a macOS notification.
+#[derive(Clone, Debug)]
+pub enum ActionResponse {
+    /// Custom action configured by the notification.
+    Custom(String),
+
+    /// The notification was closed.
+    Closed(CloseReason),
+}
+
+/// Helper trait implemented by `Fn()` and `Fn(CloseReason)`.
+pub trait CloseHandler<T> {
+    /// Calls the handler with the close reason.
+    fn call(&self, reason: CloseReason);
+}
+
+impl<F> CloseHandler<CloseReason> for F
+where
+    F: Fn(CloseReason),
+{
+    fn call(&self, reason: CloseReason) {
+        self(reason);
+    }
+}
+
+impl<F> CloseHandler<()> for F
+where
+    F: Fn(),
+{
+    fn call(&self, _: CloseReason) {
+        self();
+    }
+}
 
 /// A handle to a shown notification.
 ///
-/// This keeps a connection alive to ensure actions work on certain desktops.
-#[derive(Debug)]
+/// The handle owns the receiving side of a one-shot channel. The sending side is
+/// held by a background thread that waits for macOS to report the user's
+/// response, so creating a notification does not block the caller.
 pub struct NotificationHandle {
     notification: Notification,
+    response: Option<Receiver<ActionResponse>>,
+}
+
+impl fmt::Debug for NotificationHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NotificationHandle")
+            .field("notification", &self.notification)
+            .finish_non_exhaustive()
+    }
 }
 
 impl NotificationHandle {
     #[allow(missing_docs)]
-    pub fn new(notification: Notification) -> NotificationHandle {
-        NotificationHandle { notification }
+    pub fn new(
+        notification: Notification,
+        response: Receiver<ActionResponse>,
+    ) -> NotificationHandle {
+        NotificationHandle {
+            notification,
+            response: Some(response),
+        }
+    }
+
+    /// Waits for the user to act on a notification and then calls
+    /// `invocation_closure` with the corresponding action name.
+    ///
+    /// Clicking the notification body maps to `"default"`. Closing the
+    /// notification maps to `"__closed"` for compatibility with the XDG API.
+    /// macOS reports action button titles, so notify-rust maps a title back to
+    /// the identifier passed to [`Notification::action`] when possible.
+    pub fn wait_for_action<F>(mut self, invocation_closure: F)
+    where
+        F: FnOnce(&str),
+    {
+        if let Some(response) = self.response.take().and_then(|rx| rx.recv().ok()) {
+            match response {
+                ActionResponse::Custom(action) => invocation_closure(&action),
+                ActionResponse::Closed(_reason) => invocation_closure("__closed"),
+            }
+        }
+    }
+
+    /// Runs a callback on a background thread after macOS reports a response.
+    ///
+    /// This is the non-blocking counterpart to [`wait_for_action`](Self::wait_for_action).
+    pub fn on_response<F>(mut self, invocation_closure: F)
+    where
+        F: FnOnce(ActionResponse) + Send + 'static,
+    {
+        if let Some(response) = self.response.take() {
+            thread::spawn(move || {
+                if let Ok(response) = response.recv() {
+                    invocation_closure(response);
+                }
+            });
+        }
+    }
+
+    /// Executes a closure after the notification has closed.
+    pub fn on_close<A>(mut self, handler: impl CloseHandler<A>) {
+        if let Some(ActionResponse::Closed(reason)) =
+            self.response.take().and_then(|rx| rx.recv().ok())
+        {
+            handler.call(reason);
+        }
     }
 }
 
@@ -35,19 +147,10 @@ impl DerefMut for NotificationHandle {
 }
 
 pub(crate) fn show_notification(notification: &Notification) -> Result<NotificationHandle> {
-    let mut n = mac_notification_sys::Notification::default();
-    n.title(notification.summary.as_str())
-        .message(&notification.body)
-        .maybe_subtitle(notification.subtitle.as_deref())
-        .maybe_sound(notification.sound_name.as_deref());
-
-    if let Some(ref image_path) = notification.path_to_image {
-        n.content_image(image_path);
-    }
-
-    n.send()?;
-
-    Ok(NotificationHandle::new(notification.clone()))
+    Ok(NotificationHandle::new(
+        notification.clone(),
+        spawn_response_listener(notification),
+    ))
 }
 
 pub(crate) fn schedule_notification(
@@ -67,5 +170,107 @@ pub(crate) fn schedule_notification(
 
     n.send()?;
 
-    Ok(NotificationHandle::new(notification.clone()))
+    // mac-notification-sys exposes responses for immediate notifications only.
+    // Keep scheduled notifications on the existing scheduling path; the
+    // returned handle has no response to receive.
+    let (_sender, receiver) = mpsc::channel();
+    Ok(NotificationHandle::new(notification.clone(), receiver))
+}
+
+fn spawn_response_listener(notification: &Notification) -> Receiver<ActionResponse> {
+    let (sender, receiver) = mpsc::channel();
+    let title = notification.summary.clone();
+    let subtitle = notification.subtitle.clone();
+    let message = notification.body.clone();
+    let sound = notification.sound_name.clone();
+    let image = notification.path_to_image.clone();
+    let actions = notification.actions.clone();
+
+    thread::spawn(move || {
+        // `mac-notification-sys` blocks here until macOS reports the user's
+        // response. Keeping it on this dedicated thread means showing a
+        // notification is non-blocking for the caller; the single result is
+        // delivered through the handle's channel.
+        let mut options = mac_notification_sys::Notification::default();
+        options
+            .title(title.as_str())
+            .message(message.as_str())
+            .maybe_subtitle(subtitle.as_deref())
+            .maybe_sound(sound.as_deref());
+        if let Some(ref image_path) = image {
+            options.content_image(image_path);
+        }
+
+        let response = match options.send() {
+            Ok(response) => map_response(response, &actions),
+            Err(_) => ActionResponse::Closed(CloseReason::Other(0)),
+        };
+
+        let _ = sender.send(response);
+    });
+
+    receiver
+}
+
+/// Map `mac-notification-sys`'s response into notify-rust's action model.
+///
+/// Clicking the notification body maps to `"default"`; action buttons are
+/// mapped back to the identifier passed to [`Notification::action`] when the
+/// reported button title matches a configured label.
+fn map_response(
+    response: mac_notification_sys::NotificationResponse,
+    actions: &[String],
+) -> ActionResponse {
+    use mac_notification_sys::NotificationResponse as Response;
+
+    match response {
+        Response::Click => ActionResponse::Custom("default".to_owned()),
+        Response::ActionButton(label) | Response::Reply(label) => {
+            ActionResponse::Custom(action_identifier_for_label(&label, actions))
+        }
+        Response::CloseButton(_) => ActionResponse::Closed(CloseReason::Dismissed),
+        Response::None => ActionResponse::Closed(CloseReason::Expired),
+    }
+}
+
+fn action_identifier_for_label(action: &str, actions: &[String]) -> String {
+    actions
+        .chunks(2)
+        .find_map(|chunk| match chunk {
+            [identifier, label] if label == action => Some(identifier.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| action.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{map_response, ActionResponse, CloseReason};
+    use mac_notification_sys::NotificationResponse as Response;
+
+    #[test]
+    fn maps_click_to_default_action() {
+        match map_response(Response::Click, &[]) {
+            ActionResponse::Custom(action) => assert_eq!(action, "default"),
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_button_title_to_action_identifier() {
+        let actions = vec!["open".to_owned(), "Open".to_owned()];
+
+        match map_response(Response::ActionButton("Open".to_owned()), &actions) {
+            ActionResponse::Custom(action) => assert_eq!(action, "open"),
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_close_to_dismissed() {
+        match map_response(Response::CloseButton("Close".to_owned()), &[]) {
+            ActionResponse::Closed(CloseReason::Dismissed) => {}
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -486,12 +486,11 @@ impl Notification {
         macos::show_notification(self)
     }
 
-    /// Sends Notification to `NSUserNotificationCenter`.
+    /// Sends Notification to the Windows toast API.
     ///
-    /// Returns an `Ok` no matter what, since there is currently no way of telling the success of
-    /// the notification.
+    /// Returns a handle to a notification.
     #[cfg(target_os = "windows")]
-    pub fn show(&self) -> Result<()> {
+    pub fn show(&self) -> Result<windows::NotificationHandle> {
         windows::show_notification(self)
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,9 +2,128 @@ use winrt_notification::Toast;
 
 pub use crate::{error::*, notification::Notification, timeout::Timeout, urgency::Urgency};
 
-use std::{path::Path, str::FromStr};
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+    path::Path,
+    str::FromStr,
+};
 
-pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
+/// Reason why a notification closed.
+#[derive(Copy, Clone, Debug)]
+pub enum CloseReason {
+    /// The notification expired.
+    Expired,
+    /// The user dismissed the notification.
+    Dismissed,
+    /// The notification was closed because the user clicked an action.
+    CloseAction,
+    /// The platform did not expose a more specific reason.
+    Other(u32),
+}
+
+/// Response to a Windows toast notification.
+#[derive(Clone, Debug)]
+pub enum ActionResponse {
+    /// Custom action configured by the notification.
+    Custom(String),
+
+    /// The notification was closed.
+    Closed(CloseReason),
+}
+
+/// Helper trait implemented by `Fn()` and `Fn(CloseReason)`.
+pub trait CloseHandler<T> {
+    /// Calls the handler with the close reason.
+    fn call(&self, reason: CloseReason);
+}
+
+impl<F> CloseHandler<CloseReason> for F
+where
+    F: Fn(CloseReason),
+{
+    fn call(&self, reason: CloseReason) {
+        self(reason);
+    }
+}
+
+impl<F> CloseHandler<()> for F
+where
+    F: Fn(),
+{
+    fn call(&self, _: CloseReason) {
+        self();
+    }
+}
+
+/// A handle to a shown Windows toast notification.
+///
+/// The current `tauri-winrt-notification` API used by notify-rust can display
+/// toasts but does not expose toast activation or dismissal callbacks. The
+/// listener methods are present so cross-platform code can compile; on Windows
+/// they return without invoking the callback until the backend exposes an
+/// activation API this crate can wire through.
+pub struct NotificationHandle {
+    notification: Notification,
+}
+
+impl NotificationHandle {
+    #[allow(missing_docs)]
+    pub fn new(notification: Notification) -> NotificationHandle {
+        NotificationHandle { notification }
+    }
+
+    /// Waits for the user to act on a notification.
+    ///
+    /// Windows toast activation is not exposed by `tauri-winrt-notification`
+    /// 0.7, so this currently returns without invoking `invocation_closure`.
+    pub fn wait_for_action<F>(self, _invocation_closure: F)
+    where
+        F: FnOnce(&str),
+    {
+    }
+
+    /// Runs a callback after Windows reports a toast response.
+    ///
+    /// Windows toast activation is not exposed by `tauri-winrt-notification`
+    /// 0.7, so this currently returns without invoking `invocation_closure`.
+    pub fn on_response<F>(self, _invocation_closure: F)
+    where
+        F: FnOnce(ActionResponse) + Send + 'static,
+    {
+    }
+
+    /// Executes a closure after the notification has closed.
+    ///
+    /// Windows toast dismissal is not exposed by `tauri-winrt-notification`
+    /// 0.7, so this currently returns without invoking `handler`.
+    pub fn on_close<A>(self, _handler: impl CloseHandler<A>) {}
+}
+
+impl fmt::Debug for NotificationHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NotificationHandle")
+            .field("notification", &self.notification)
+            .finish()
+    }
+}
+
+impl Deref for NotificationHandle {
+    type Target = Notification;
+
+    fn deref(&self) -> &Notification {
+        &self.notification
+    }
+}
+
+/// Allow to easily modify notification properties.
+impl DerefMut for NotificationHandle {
+    fn deref_mut(&mut self) -> &mut Notification {
+        &mut self.notification
+    }
+}
+
+pub(crate) fn show_notification(notification: &Notification) -> Result<NotificationHandle> {
     let sound = match &notification.sound_name {
         Some(chosen_sound_name) => winrt_notification::Sound::from_str(chosen_sound_name).ok(),
         None => None,
@@ -49,5 +168,7 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
 
     toast
         .show()
-        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))
+        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))?;
+
+    Ok(NotificationHandle::new(notification.clone()))
 }


### PR DESCRIPTION
Closes #186.

Implements notification **action / click / close listeners** for macOS (fully) and Windows (wired), so callers can learn which notification/action the user interacted with — mirroring the existing XDG (`wait_for_action` / `on_close`) ergonomics.

## macOS (functional)
- `NotificationHandle` now exposes `wait_for_action`, `on_response`, and `on_close`, mirroring the XDG API.
- **Non-blocking by design.** `mac-notification-sys` blocks until the user responds; this runs that wait on a dedicated `std::thread` and delivers the single result through an `mpsc` channel owned by the handle. `show()` returns immediately — addressing the 100% CPU / blocking behaviour called out in the issue.
- `mac_notification_sys::NotificationResponse` is mapped into notify-rust's action model: body click → `"default"`, action buttons → the identifier configured via `Notification::action(..)` (matched by label), close/none → close reasons.
- Added response-mapping unit tests and an `examples/listen.rs`.

## Windows (wired, with a documented limitation)
- `Notification::show()` now returns `Result<NotificationHandle>` (was `Result<()>`) for cross-platform consistency, and the handle exposes the same listener methods.
- `tauri-winrt-notification` 0.7 (the current Windows backend) does **not** expose toast activation/dismissal callbacks, so these methods are **documented stubs** for now — present so cross-platform code compiles, ready to wire through once the backend exposes an activation API. Existing toast behaviour is unchanged.

## Testing
- macOS: `cargo build`, `cargo test` (new mapping tests pass), `cargo clippy` — all green.
- Linux/XDG: untouched; existing listener behaviour preserved.
- ⚠️ I don't have a Windows host, so I couldn't build the Windows target locally — please verify that path in CI. The Windows change is structural (return type + handle), mirroring the macOS pattern.

## API summary
- macOS & Windows now export `ActionResponse`, `CloseReason`, `CloseHandler`, `NotificationHandle`.
- New handle methods: `wait_for_action(FnOnce(&str))`, `on_response(FnOnce(ActionResponse) + Send + 'static)`, `on_close(impl CloseHandler)`.

Happy to adjust naming/semantics to your preferences.

/claim #186
