### PR TITLE
draft: add Windows notification handle listeners

### DIFF
--- a/examples/actions.rs
+++ b/examples/actions.rs
@@ -1,36 +1,43 @@
 #![allow(unused_imports)]
 use notify_rust::{Hint, Notification, Timeout};
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 fn main() {
     println!("this is a xdg only feature");
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
 fn main() {
-    Notification::new()
+    let mut first = Notification::new();
+    first
         .summary("click me")
         .body("This will disappear by itself")
-        .action("clicked_a", "button a") // IDENTIFIER, LABEL
-        .hint(Hint::Transient(true)) // needed to work on kde
-        .show()
+        .action("clicked_a", "button a");
+    #[cfg(all(unix, not(target_os = "macos")))]
+    first.hint(Hint::Transient(true));
+    first
+        .show_handle()
         .unwrap()
         .wait_for_action(|action| match action {
             "clicked_a" => println!("clicked a"),
+            "default" => println!("default"),
             // FIXME: here "__closed" is a hardcoded keyword, it will be deprecated!!
             "__closed" => println!("the notification was closed"),
             _ => (),
         });
 
-    Notification::new()
+    let mut second = Notification::new();
+    second
         .summary("click me")
         .body("This action needs to be clicked")
-        .action("default", "default") // IDENTIFIER, LABEL
-        .action("clicked_a", "button a") // IDENTIFIER, LABEL
-        .action("clicked_b", "button b") // IDENTIFIER, LABEL
-        .hint(Hint::Resident(true)) // does not work on kde
-        .timeout(Timeout::Never) // works on kde and gnome
-        .show()
+        .action("default", "default")
+        .action("clicked_a", "button a")
+        .action("clicked_b", "button b")
+        .timeout(Timeout::Never);
+    #[cfg(all(unix, not(target_os = "macos")))]
+    second.hint(Hint::Resident(true));
+    second
+        .show_handle()
         .unwrap()
         .wait_for_action(|action| match action {
             "default" => println!("default"),

--- a/examples/on_close.rs
+++ b/examples/on_close.rs
@@ -12,20 +12,20 @@ fn print() {
     println!("notification was closed, don't know why");
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 fn main() {
     println!("this is a xdg only feature")
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
 fn main() {
     thread::spawn(|| {
         Notification::new()
             .summary("Time is running out")
             .body("This will go away.")
             .icon("clock")
-            .show()
-            .map(|handler| handler.on_close(print))
+            .show_handle()
+            .map(|handler| handler.on_close(|_| print()))
     });
     wait_for_keypress();
 }

--- a/examples/on_close_reason.rs
+++ b/examples/on_close_reason.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports, dead_code)]
 use std::{io, thread};
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
 use notify_rust::{CloseReason, Notification};
 
 fn wait_for_keypress() {
@@ -9,24 +9,24 @@ fn wait_for_keypress() {
     io::stdin().read_line(&mut String::new()).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
 fn print_reason(reason: CloseReason) {
     println!("notification was closed ({:?})", reason);
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(target_os = "macos")]
 fn main() {
     println!("this is a xdg only feature")
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
 fn main() {
     thread::spawn(|| {
         Notification::new()
             .summary("Time is running out")
             .body("This will go away.")
             .icon("clock")
-            .show()
+            .show_handle()
             .map(|handler| handler.on_close(print_reason))
     });
     wait_for_keypress();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,9 @@ pub use mac_notification_sys::{get_bundle_identifier_or_default, set_application
 #[cfg(target_os = "macos")]
 pub use macos::NotificationHandle;
 
+#[cfg(target_os = "windows")]
+pub use windows::{CloseReason, NotificationHandle};
+
 #[cfg(all(
     any(feature = "dbus", feature = "zbus"),
     unix,

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -495,6 +495,26 @@ impl Notification {
         windows::show_notification(self)
     }
 
+    /// Sends a notification and returns a handle that can listen for activation and close events.
+    ///
+    /// On Windows, clicking the notification body is surfaced as the `"default"` action.
+    #[cfg(target_os = "windows")]
+    pub fn show_handle(&self) -> Result<windows::NotificationHandle> {
+        windows::show_notification_handle(self)
+    }
+
+    /// Alias for [`Notification::show()`], useful when generic code wants a handle explicitly.
+    #[cfg(target_os = "macos")]
+    pub fn show_handle(&self) -> Result<macos::NotificationHandle> {
+        self.show()
+    }
+
+    /// Alias for [`Notification::show()`], useful when generic code wants a handle explicitly.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    pub fn show_handle(&self) -> Result<xdg::NotificationHandle> {
+        self.show()
+    }
+
     /// Wraps [`Notification::show()`] but prints notification to stdout.
     #[cfg(all(unix, not(target_os = "macos")))]
     #[deprecated = "this was never meant to be public API"]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,10 +1,86 @@
-use winrt_notification::Toast;
+use std::{
+    ops::{Deref, DerefMut},
+    path::Path,
+    str::FromStr,
+    sync::mpsc::{self, Receiver, Sender},
+};
+
+use winrt_notification::{Toast, ToastDismissalReason};
 
 pub use crate::{error::*, notification::Notification, timeout::Timeout, urgency::Urgency};
 
-use std::{path::Path, str::FromStr};
+#[derive(Copy, Clone, Debug)]
+pub enum CloseReason {
+    Expired,
+    Dismissed,
+    CloseAction,
+    Other,
+}
 
-pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
+enum ToastEvent {
+    Activated(Option<String>),
+    Dismissed(CloseReason),
+}
+
+pub struct NotificationHandle {
+    events: Receiver<ToastEvent>,
+    notification: Notification,
+}
+
+impl NotificationHandle {
+    pub fn wait_for_action<F>(self, invocation_closure: F)
+    where
+        F: FnOnce(&str),
+    {
+        match self.events.recv() {
+            Ok(ToastEvent::Activated(Some(action))) => invocation_closure(action.as_str()),
+            Ok(ToastEvent::Activated(None)) => invocation_closure("default"),
+            Ok(ToastEvent::Dismissed(_)) | Err(_) => invocation_closure("__closed"),
+        }
+    }
+
+    pub fn on_close<F>(self, handler: F)
+    where
+        F: FnOnce(CloseReason),
+    {
+        while let Ok(event) = self.events.recv() {
+            if let ToastEvent::Dismissed(reason) = event {
+                handler(reason);
+                break;
+            }
+        }
+    }
+}
+
+impl Deref for NotificationHandle {
+    type Target = Notification;
+
+    fn deref(&self) -> &Notification {
+        &self.notification
+    }
+}
+
+impl DerefMut for NotificationHandle {
+    fn deref_mut(&mut self) -> &mut Notification {
+        &mut self.notification
+    }
+}
+
+impl From<Option<ToastDismissalReason>> for CloseReason {
+    fn from(reason: Option<ToastDismissalReason>) -> Self {
+        match reason {
+            Some(ToastDismissalReason::TimedOut) => CloseReason::Expired,
+            Some(ToastDismissalReason::UserCanceled) => CloseReason::Dismissed,
+            Some(ToastDismissalReason::ApplicationHidden) => CloseReason::CloseAction,
+            None => CloseReason::Other,
+        }
+    }
+}
+
+fn build_toast(
+    notification: &Notification,
+    event_tx: Option<Sender<ToastEvent>>,
+) -> Result<Toast> {
     let sound = match &notification.sound_name {
         Some(chosen_sound_name) => winrt_notification::Sound::from_str(chosen_sound_name).ok(),
         None => None,
@@ -22,32 +98,74 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
         }
     };
 
-    // Map urgency to Windows toast scenario
-    // Low/Normal -> Default (standard behavior)
-    // Critical -> Reminder (stays on screen until dismissed, matching XDG spec)
     let scenario = match notification.urgency {
-        Some(Urgency::Critical) => Some(winrt_notification::Scenario::Reminder),
-        Some(Urgency::Low) | Some(Urgency::Normal) | None => None, // Default scenario
+        Some(Urgency::Critical) => winrt_notification::Scenario::Reminder,
+        Some(Urgency::Low) | Some(Urgency::Normal) | None => winrt_notification::Scenario::Default,
     };
 
-    let powershell_app_id = &Toast::POWERSHELL_APP_ID.to_string();
-    let app_id = &notification.app_id.as_ref().unwrap_or(powershell_app_id);
+    let app_id = notification.app_id.as_deref().unwrap_or(Toast::POWERSHELL_APP_ID);
     let mut toast = Toast::new(app_id)
         .title(&notification.summary)
-        .text1(notification.subtitle.as_ref().map_or("", AsRef::as_ref)) // subtitle
+        .text1(notification.subtitle.as_deref().unwrap_or(""))
         .text2(&notification.body)
         .sound(sound)
-        .duration(duration);
+        .duration(duration)
+        .scenario(scenario);
 
-    // Apply scenario only for critical urgency
-    if let Some(scenario) = scenario {
-        toast = toast.scenario(scenario);
-    }
     if let Some(image_path) = &notification.path_to_image {
-        toast = toast.image(Path::new(&image_path), "");
+        toast = toast.image(Path::new(image_path), "");
     }
+
+    for action in notification.actions.chunks_exact(2) {
+        toast = toast.add_button(&action[1], &action[0]);
+    }
+
+    if let Some(action_tx) = event_tx {
+        let dismissed_tx = action_tx.clone();
+        toast = toast
+            .on_activated(move |action| {
+                let _ = action_tx.send(ToastEvent::Activated(action));
+                Ok(())
+            })
+            .on_dismissed(move |reason| {
+                let _ = dismissed_tx.send(ToastEvent::Dismissed(reason.into()));
+                Ok(())
+            });
+    }
+
+    Ok(toast)
+}
+
+pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
+    build_toast(notification, None)?
+        .show()
+        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))
+}
+
+pub(crate) fn show_notification_handle(notification: &Notification) -> Result<NotificationHandle> {
+    let (tx, rx) = mpsc::channel();
+    let toast = build_toast(notification, Some(tx))?;
 
     toast
         .show()
-        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))
+        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))?;
+
+    Ok(NotificationHandle {
+        events: rx,
+        notification: notification.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CloseReason;
+    use winrt_notification::ToastDismissalReason;
+
+    #[test]
+    fn maps_missing_dismiss_reason_to_other() {
+        assert!(matches!(
+            CloseReason::from(None::<ToastDismissalReason>),
+            CloseReason::Other
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

This draft PR takes the Windows slice of #186 without breaking the existing Windows `show()` signature.

What it adds:
- a Windows `NotificationHandle`
- `Notification::show_handle()` on Windows to return that handle
- Windows `NotificationHandle::wait_for_action(...)`
- Windows `NotificationHandle::on_close(...)`
- Windows toast activation/dismissal wiring on top of the existing `tauri-winrt-notification` dependency
- example updates so the listener examples now work on Windows too

## Why this shape

In the issue thread I proposed keeping this additive first instead of changing Windows `show()` from `Result<()>` to a handle-returning API in one step.
That lets existing Windows callers keep working while still enabling listener support for apps that need it.

## Notes

- body-click activation on Windows is surfaced as the `"default"` action
- close reasons are mapped from WinRT dismissal reasons into a small `CloseReason` enum for Windows
- `show()` stays fire-and-forget; `show_handle()` is the opt-in listener path

## Verification

I could not complete local Rust verification in this environment because the current desktop session does not have the MSVC SDK/linker libraries available (`link.exe` / `kernel32.lib` etc.).
So this PR is intentionally opened as a draft first so GitHub Actions can provide the authoritative compile signal.

Refs #186
