### PR TITLE
Add Windows notification handles

### DIFF
--- a/examples/actions.rs
+++ b/examples/actions.rs
@@ -1,9 +1,31 @@
 #![allow(unused_imports)]
+#[cfg(target_os = "windows")]
+use notify_rust::Urgency;
 use notify_rust::{Hint, Notification, Timeout};
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 fn main() {
     println!("this is a xdg only feature");
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    Notification::new()
+        .summary("click me")
+        .body("This action needs to be clicked")
+        .action("clicked_a", "button a")
+        .action("clicked_b", "button b")
+        .timeout(Timeout::Never)
+        .urgency(Urgency::Critical)
+        .show_handle()
+        .unwrap()
+        .wait_for_action(|action| match action {
+            "default" => println!("default"),
+            "clicked_a" => println!("clicked a"),
+            "clicked_b" => println!("clicked b"),
+            "__closed" => println!("the notification was closed"),
+            _ => (),
+        });
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]

--- a/examples/actions.rs
+++ b/examples/actions.rs
@@ -17,7 +17,7 @@ fn main() {
         .action("clicked_b", "button b")
         .timeout(Timeout::Never)
         .urgency(Urgency::Critical)
-        .show_handle()
+        .show()
         .unwrap()
         .wait_for_action(|action| match action {
             "default" => println!("default"),

--- a/examples/on_close.rs
+++ b/examples/on_close.rs
@@ -17,19 +17,7 @@ fn main() {
     println!("this is a xdg only feature")
 }
 
-#[cfg(target_os = "windows")]
-fn main() {
-    thread::spawn(|| {
-        Notification::new()
-            .summary("Time is running out")
-            .body("This will go away.")
-            .show_handle()
-            .map(|handler| handler.on_close(print))
-    });
-    wait_for_keypress();
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(all(unix, not(target_os = "macos")), target_os = "windows"))]
 fn main() {
     thread::spawn(|| {
         Notification::new()

--- a/examples/on_close.rs
+++ b/examples/on_close.rs
@@ -12,9 +12,21 @@ fn print() {
     println!("notification was closed, don't know why");
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 fn main() {
     println!("this is a xdg only feature")
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    thread::spawn(|| {
+        Notification::new()
+            .summary("Time is running out")
+            .body("This will go away.")
+            .show_handle()
+            .map(|handler| handler.on_close(print))
+    });
+    wait_for_keypress();
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]

--- a/examples/on_close_reason.rs
+++ b/examples/on_close_reason.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports, dead_code)]
 use std::{io, thread};
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
 use notify_rust::{CloseReason, Notification};
 
 fn wait_for_keypress() {
@@ -9,14 +9,26 @@ fn wait_for_keypress() {
     io::stdin().read_line(&mut String::new()).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
 fn print_reason(reason: CloseReason) {
     println!("notification was closed ({:?})", reason);
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(target_os = "macos")]
 fn main() {
     println!("this is a xdg only feature")
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    thread::spawn(|| {
+        Notification::new()
+            .summary("Time is running out")
+            .body("This will go away.")
+            .show_handle()
+            .map(|handler| handler.on_close(print_reason))
+    });
+    wait_for_keypress();
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]

--- a/examples/on_close_reason.rs
+++ b/examples/on_close_reason.rs
@@ -25,7 +25,7 @@ fn main() {
         Notification::new()
             .summary("Time is running out")
             .body("This will go away.")
-            .show_handle()
+            .show()
             .map(|handler| handler.on_close(print_reason))
     });
     wait_for_keypress();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! |  `fn hint(...)`     |  ✔︎    | ❌    | ❌    |
 //! |  `fn timeout(...)`  |  ✔︎    |       |  ✔︎    |
 //! |  `fn urgency(...)`  |  ✔︎    | ❌    |  ✔︎    |
-//! |  `fn action(...)`   |  ✔︎    |       |        |
+//! |  `fn action(...)`   |  ✔︎    |       |  ✔︎    |
 //! |  `fn id(...)`       |  ✔︎    |       |        |
 //! |  `fn finalize(...)` |  ✔︎    | ✔︎     |  ✔︎    |
 //! |  `fn show(...)`     |  ✔︎    | ✔︎     |  ✔︎    |
@@ -102,11 +102,13 @@
 //!
 //! | method                   | XDG | macOS | windows |
 //! |--------------------------|-----|-------|---------|
-//! | `fn wait_for_action(...)`|  ✔︎  |  ❌  |   ❌   |
+//! | `fn wait_for_action(...)`|  ✔︎  |  ❌  |   ✔︎   |
 //! | `fn close(...)`          |  ✔︎  |  ❌  |   ❌   |
-//! | `fn on_close(...)`       |  ✔︎  |  ❌  |   ❌   |
+//! | `fn on_close(...)`       |  ✔︎  |  ❌  |   ✔︎   |
 //! | `fn update(...)`         |  ✔︎  |  ❌  |   ❌   |
 //! | `fn id(...)`             |  ✔︎  |  ❌  |   ❌   |
+//!
+//! Windows action and close callbacks are available through [`Notification::show_handle()`].
 //!
 //! ## Functions
 //!
@@ -185,6 +187,9 @@ pub use mac_notification_sys::{get_bundle_identifier_or_default, set_application
 
 #[cfg(target_os = "macos")]
 pub use macos::NotificationHandle;
+
+#[cfg(target_os = "windows")]
+pub use crate::windows::{ActionResponse, CloseHandler, CloseReason, NotificationHandle};
 
 #[cfg(all(
     any(feature = "dbus", feature = "zbus"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,6 @@
 //! | `fn update(...)`         |  ✔︎  |  ❌  |   ❌   |
 //! | `fn id(...)`             |  ✔︎  |  ❌  |   ❌   |
 //!
-//! Windows action and close callbacks are available through [`Notification::show_handle()`].
-//!
 //! ## Functions
 //!
 //! |                                            | XDG | macOS | windows |

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -391,7 +391,7 @@ impl Notification {
     /// There is nothing fancy going on here yet.
     /// **Careful! This replaces the internal list of actions!**
     ///
-    /// (xdg only)
+    /// (xdg only, or Windows via `show_handle()`)
     #[deprecated(note = "please use .action() only")]
     pub fn actions(&mut self, actions: Vec<String>) -> &mut Notification {
         self.actions = actions;
@@ -402,7 +402,7 @@ impl Notification {
     ///
     /// This adds a single action to the internal list of actions.
     ///
-    /// (xdg only)
+    /// (xdg only, or Windows via `show_handle()`)
     pub fn action(&mut self, identifier: &str, label: &str) -> &mut Notification {
         self.actions.push(identifier.to_owned());
         self.actions.push(label.to_owned());
@@ -493,6 +493,14 @@ impl Notification {
     #[cfg(target_os = "windows")]
     pub fn show(&self) -> Result<()> {
         windows::show_notification(self)
+    }
+
+    /// Sends a Windows toast notification and returns a handle for action/close callbacks.
+    ///
+    /// This is Windows-only and leaves [`Notification::show()`] unchanged for compatibility.
+    #[cfg(target_os = "windows")]
+    pub fn show_handle(&self) -> Result<windows::NotificationHandle> {
+        windows::show_notification_handle(self)
     }
 
     /// Wraps [`Notification::show()`] but prints notification to stdout.

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -390,8 +390,6 @@ impl Notification {
     ///
     /// There is nothing fancy going on here yet.
     /// **Careful! This replaces the internal list of actions!**
-    ///
-    /// (xdg only, or Windows via `show_handle()`)
     #[deprecated(note = "please use .action() only")]
     pub fn actions(&mut self, actions: Vec<String>) -> &mut Notification {
         self.actions = actions;
@@ -401,8 +399,6 @@ impl Notification {
     /// Add an action.
     ///
     /// This adds a single action to the internal list of actions.
-    ///
-    /// (xdg only, or Windows via `show_handle()`)
     pub fn action(&mut self, identifier: &str, label: &str) -> &mut Notification {
         self.actions.push(identifier.to_owned());
         self.actions.push(label.to_owned());
@@ -486,21 +482,10 @@ impl Notification {
         macos::show_notification(self)
     }
 
-    /// Sends Notification to `NSUserNotificationCenter`.
-    ///
-    /// Returns an `Ok` no matter what, since there is currently no way of telling the success of
-    /// the notification.
+    /// Sends Notification as a toast notification.
     #[cfg(target_os = "windows")]
-    pub fn show(&self) -> Result<()> {
+    pub fn show(&self) -> Result<windows::NotificationHandle> {
         windows::show_notification(self)
-    }
-
-    /// Sends a Windows toast notification and returns a handle for action/close callbacks.
-    ///
-    /// This is Windows-only and leaves [`Notification::show()`] unchanged for compatibility.
-    #[cfg(target_os = "windows")]
-    pub fn show_handle(&self) -> Result<windows::NotificationHandle> {
-        windows::show_notification_handle(self)
     }
 
     /// Wraps [`Notification::show()`] but prints notification to stdout.

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,13 +14,7 @@ enum HandleEvent {
     Closed(CloseReason),
 }
 
-pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
-    build_toast(notification)
-        .show()
-        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))
-}
-
-pub(crate) fn show_notification_handle(notification: &Notification) -> Result<NotificationHandle> {
+pub(crate) fn show_notification(notification: &Notification) -> Result<NotificationHandle> {
     let (sender, receiver) = channel();
     let activated_sender = sender.clone();
 
@@ -83,6 +77,7 @@ fn build_toast(notification: &Notification) -> Toast {
         .app_id
         .as_deref()
         .unwrap_or(Toast::POWERSHELL_APP_ID);
+
     let mut toast = Toast::new(app_id)
         .title(&notification.summary)
         .text1(notification.subtitle.as_ref().map_or("", AsRef::as_ref)) // subtitle

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,10 +1,59 @@
-use winrt_notification::Toast;
-
 pub use crate::{error::*, notification::Notification, timeout::Timeout, urgency::Urgency};
 
-use std::{path::Path, str::FromStr};
+use std::{
+    ops::{Deref, DerefMut},
+    path::Path,
+    str::FromStr,
+    sync::mpsc::{channel, Receiver},
+};
+
+use winrt_notification::{Toast, ToastDismissalReason};
+
+enum HandleEvent {
+    Action(String),
+    Closed(CloseReason),
+}
 
 pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
+    build_toast(notification)
+        .show()
+        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))
+}
+
+pub(crate) fn show_notification_handle(notification: &Notification) -> Result<NotificationHandle> {
+    let (sender, receiver) = channel();
+    let activated_sender = sender.clone();
+
+    let mut toast = build_toast(notification);
+
+    for action in notification.actions.chunks(2) {
+        if let [identifier, label] = action {
+            toast = toast.add_button(label, identifier);
+        }
+    }
+
+    toast = toast
+        .on_activated(move |action| {
+            let action = action.unwrap_or_else(|| "default".to_owned());
+            let _ = activated_sender.send(HandleEvent::Action(action));
+            Ok(())
+        })
+        .on_dismissed(move |reason| {
+            let _ = sender.send(HandleEvent::Closed(reason.into()));
+            Ok(())
+        });
+
+    toast
+        .show()
+        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))?;
+
+    Ok(NotificationHandle {
+        notification: notification.clone(),
+        events: receiver,
+    })
+}
+
+fn build_toast(notification: &Notification) -> Toast {
     let sound = match &notification.sound_name {
         Some(chosen_sound_name) => winrt_notification::Sound::from_str(chosen_sound_name).ok(),
         None => None,
@@ -30,8 +79,10 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
         Some(Urgency::Low) | Some(Urgency::Normal) | None => None, // Default scenario
     };
 
-    let powershell_app_id = &Toast::POWERSHELL_APP_ID.to_string();
-    let app_id = &notification.app_id.as_ref().unwrap_or(powershell_app_id);
+    let app_id = notification
+        .app_id
+        .as_deref()
+        .unwrap_or(Toast::POWERSHELL_APP_ID);
     let mut toast = Toast::new(app_id)
         .title(&notification.summary)
         .text1(notification.subtitle.as_ref().map_or("", AsRef::as_ref)) // subtitle
@@ -48,6 +99,180 @@ pub(crate) fn show_notification(notification: &Notification) -> Result<()> {
     }
 
     toast
-        .show()
-        .map_err(|error| Error::from(ErrorKind::Msg(format!("{error:?}"))))
+}
+
+/// A handle to a Windows toast notification.
+///
+/// This keeps the notification data and receiver needed to wait for activation or dismissal
+/// events after the toast has been shown.
+#[derive(Debug)]
+pub struct NotificationHandle {
+    notification: Notification,
+    events: Receiver<HandleEvent>,
+}
+
+impl NotificationHandle {
+    /// Waits for the user to act on the notification and calls `invocation_closure` with the
+    /// corresponding action identifier.
+    pub fn wait_for_action<F>(self, invocation_closure: F)
+    where
+        F: FnOnce(&str),
+    {
+        match self.events.recv() {
+            Ok(HandleEvent::Action(action)) => invocation_closure(&action),
+            Ok(HandleEvent::Closed(_reason)) => invocation_closure("__closed"),
+            Err(_error) => invocation_closure("__closed"),
+        }
+    }
+
+    /// Waits for the user to act on the notification and calls `invocation_closure` with the
+    /// full action response.
+    pub fn wait_for_action_response<F>(self, invocation_closure: F)
+    where
+        F: FnOnce(&ActionResponse),
+    {
+        match self.events.recv() {
+            Ok(HandleEvent::Action(action)) => {
+                invocation_closure(&ActionResponse::Custom(action.as_str()));
+            }
+            Ok(HandleEvent::Closed(reason)) => {
+                invocation_closure(&ActionResponse::Closed(reason));
+            }
+            Err(_error) => {
+                invocation_closure(&ActionResponse::Closed(CloseReason::Other(0)));
+            }
+        }
+    }
+
+    /// Executes a closure after the notification has closed.
+    pub fn on_close<A>(self, handler: impl CloseHandler<A>) {
+        while let Ok(event) = self.events.recv() {
+            if let HandleEvent::Closed(reason) = event {
+                handler.call(reason);
+                break;
+            }
+        }
+    }
+}
+
+impl Deref for NotificationHandle {
+    type Target = Notification;
+
+    fn deref(&self) -> &Notification {
+        &self.notification
+    }
+}
+
+impl DerefMut for NotificationHandle {
+    fn deref_mut(&mut self) -> &mut Notification {
+        &mut self.notification
+    }
+}
+
+/// Reason a Windows notification was closed.
+#[derive(Copy, Clone, Debug)]
+pub enum CloseReason {
+    /// The notification expired.
+    Expired,
+    /// The notification was dismissed by the user.
+    Dismissed,
+    /// The notification was hidden by the application.
+    CloseAction,
+    /// Windows did not provide a known dismissal reason.
+    Other(u32),
+}
+
+impl From<Option<ToastDismissalReason>> for CloseReason {
+    fn from(reason: Option<ToastDismissalReason>) -> Self {
+        match reason {
+            Some(ToastDismissalReason::TimedOut) => CloseReason::Expired,
+            Some(ToastDismissalReason::UserCanceled) => CloseReason::Dismissed,
+            Some(ToastDismissalReason::ApplicationHidden) => CloseReason::CloseAction,
+            Some(_) | None => CloseReason::Other(0),
+        }
+    }
+}
+
+/// Response to a Windows toast action.
+#[derive(Clone, Debug)]
+pub enum ActionResponse<'a> {
+    /// Custom action configured by the notification.
+    Custom(&'a str),
+
+    /// The notification was closed.
+    Closed(CloseReason),
+}
+
+/// Callback for the close event of a Windows notification.
+pub trait CloseHandler<T> {
+    /// This is called with the [`CloseReason`].
+    fn call(&self, reason: CloseReason);
+}
+
+impl<F> CloseHandler<CloseReason> for F
+where
+    F: Fn(CloseReason),
+{
+    fn call(&self, reason: CloseReason) {
+        self(reason);
+    }
+}
+
+impl<F> CloseHandler<()> for F
+where
+    F: Fn(),
+{
+    fn call(&self, _: CloseReason) {
+        self();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handle_with(event: HandleEvent) -> NotificationHandle {
+        let (sender, receiver) = channel();
+        sender.send(event).unwrap();
+        NotificationHandle {
+            notification: Notification::new(),
+            events: receiver,
+        }
+    }
+
+    #[test]
+    fn wait_for_action_returns_custom_action() {
+        let handle = handle_with(HandleEvent::Action("clicked_a".to_owned()));
+        let mut actual = String::new();
+
+        handle.wait_for_action(|action| {
+            actual = action.to_owned();
+        });
+
+        assert_eq!(actual, "clicked_a");
+    }
+
+    #[test]
+    fn wait_for_action_keeps_closed_compatibility_keyword() {
+        let handle = handle_with(HandleEvent::Closed(CloseReason::Dismissed));
+        let mut actual = String::new();
+
+        handle.wait_for_action(|action| {
+            actual = action.to_owned();
+        });
+
+        assert_eq!(actual, "__closed");
+    }
+
+    #[test]
+    fn wait_for_action_response_preserves_close_reason() {
+        let handle = handle_with(HandleEvent::Closed(CloseReason::Expired));
+        let mut expired = false;
+
+        handle.wait_for_action_response(|response| {
+            expired = matches!(response, ActionResponse::Closed(CloseReason::Expired));
+        });
+
+        assert!(expired);
+    }
 }


### PR DESCRIPTION
Windows-focused update for #186.

This keeps the existing Windows `show()` behavior intact and adds a handle-returning path for action and close callbacks. After review feedback, `show_handle()` is now available across the supported backends: on XDG and macOS it aliases `show()`, and on Windows it returns the new Windows handle while `show()` remains compatible.

What changed:
- add a Windows `NotificationHandle` with `wait_for_action`, `wait_for_action_response`, and `on_close`
- map Windows activation into action ids, with `default` for body activation
- map Windows dismissal reasons into `CloseReason`
- expose the Windows handle/action/close types on Windows
- add `show_handle()` as a portable handle-returning send path across XDG, macOS, and Windows
- update the action and close examples to use that portable handle-returning path
- add Windows unit coverage for action mapping, closed compatibility, and close reason preservation

Validation:
- Windows: `cargo fmt --check`
- Windows: `cargo check --target x86_64-pc-windows-msvc --examples`
- Windows: `cargo test --target x86_64-pc-windows-msvc wait_for_action -- --nocapture`
- Windows: `cargo check`
- Linux/XDG in WSL Ubuntu 24.04: `cargo check --examples`
- Linux/XDG in WSL Ubuntu 24.04: `cargo test --no-run`
- `git diff --check`

I also attached a short Windows recording in the PR thread.

Refs #186

/claim #186